### PR TITLE
Make TextView.afterTextChangeEvents(): Flow public

### DIFF
--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
@@ -106,7 +106,7 @@ fun TextView.afterTextChangeEvents(
  * *Note:* A value will be emitted immediately on collect.
  */
 @CheckResult
-private fun TextView.afterTextChangeEvents(): Flow<TextViewAfterTextChangeEvent> = channelFlow {
+fun TextView.afterTextChangeEvents(): Flow<TextViewAfterTextChangeEvent> = channelFlow {
     offer(initialValue(this@afterTextChangeEvents))
     val listener = listener(this, this@afterTextChangeEvents, ::offer)
     awaitClose { removeTextChangedListener(listener) }


### PR DESCRIPTION
This seemed like an oversight, feel free to close if it's not supposed to be public