### PR TITLE
Use supported Kotlin build matrix

### DIFF
--- a/build-logic/convention/src/main/kotlin/ru/ldralighieri/corbind/Project+configureKotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/ru/ldralighieri/corbind/Project+configureKotlinAndroid.kt
@@ -39,6 +39,11 @@ internal fun Project.configureKotlinAndroid(
         defaultConfig.apply {
             this.minSdk = minSdk.toInt()
         }
+
+        compileOptions.apply {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
     }
 
     kotlin {
@@ -46,7 +51,7 @@ internal fun Project.configureKotlinAndroid(
 
         compilerOptions {
             allWarningsAsErrors.set(true)
-            jvmTarget.set(JvmTarget.JVM_21)
+            jvmTarget.set(JvmTarget.JVM_17)
             languageVersion.set(KotlinVersion.KOTLIN_2_2)
             freeCompilerArgs.addAll(
                 listOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ bcv = "0.18.1"
 gver = "0.54.0"
 
 # Kotlin
-kotlin = "2.3.21"
+kotlin = "2.4.20"
 kotlinCoroutines = "1.11.0"
 
 # Androidx

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -57,8 +57,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     packaging {


### PR DESCRIPTION
## Summary

- Update Kotlin and KGP from 2.3.21 to 2.4.20 to use the officially supported Gradle 9.6.1 and AGP 9.3.1 matrix.
- Keep JDK 21 as the build toolchain while targeting Java 17 bytecode in Android library modules and the sample app.
- Preserve Kotlin language version 2.2 to avoid changing the published metadata contract.
