### PR TITLE
Fix widget listener cleanup

### DIFF
--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
@@ -50,7 +50,7 @@ fun PopupMenu.dismisses(
     }
 
     setOnDismissListener(listener(scope, events::trySend))
-    events.invokeOnClose { setOnMenuItemClickListener(null) }
+    events.invokeOnClose { setOnDismissListener(null) }
 }
 
 /**
@@ -93,7 +93,7 @@ fun PopupMenu.dismisses(
     capacity: Int = Channel.RENDEZVOUS,
 ): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
     setOnDismissListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    invokeOnClose { setOnDismissListener(null) }
 }
 
 /**
@@ -114,7 +114,7 @@ fun PopupMenu.dismisses(
 @CheckResult
 fun PopupMenu.dismisses(): Flow<Unit> = channelFlow {
     setOnDismissListener(listener(this, ::trySend))
-    awaitClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnDismissListener(null) }
 }
 
 @CheckResult

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
@@ -94,7 +94,7 @@ fun Chip.closeIconClicks(
     capacity: Int = Channel.RENDEZVOUS,
 ): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
     setOnCloseIconClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnClickListener(null) }
+    invokeOnClose { setOnCloseIconClickListener(null) }
 }
 
 /**
@@ -115,7 +115,7 @@ fun Chip.closeIconClicks(
 @CheckResult
 fun Chip.closeIconClicks(): Flow<Unit> = channelFlow {
     setOnCloseIconClickListener(listener(this, ::trySend))
-    awaitClose { setOnClickListener(null) }
+    awaitClose { setOnCloseIconClickListener(null) }
 }
 
 @CheckResult

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
@@ -53,7 +53,7 @@ fun MaterialCardView.checkedChanges(
     events.trySend(isChecked)
     val listener = listener(scope, events::trySend)
     setOnCheckedChangeListener(listener)
-    events.invokeOnClose { setOnCheckedChangeListener(listener) }
+    events.invokeOnClose { setOnCheckedChangeListener(null) }
 }
 
 /**
@@ -99,7 +99,7 @@ fun MaterialCardView.checkedChanges(
     trySend(isChecked)
     val listener = listener(scope, ::trySend)
     setOnCheckedChangeListener(listener)
-    invokeOnClose { setOnCheckedChangeListener(listener) }
+    invokeOnClose { setOnCheckedChangeListener(null) }
 }
 
 /**


### PR DESCRIPTION
- Clear the MaterialCardView checked listener when bindings close.
- Clear the PopupMenu dismiss listener without removing its menu item click listener.
- Clear the Chip close icon listener without removing its regular click listener.