### PR TITLE
Use callbackFlow for callback bindings

### DIFF
--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackPresses.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackPresses.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -110,7 +110,7 @@ fun OnBackPressedDispatcher.backPresses(
  *
  * @param lifecycleOwner The LifecycleOwner which controls when the callback should be invoked
  */
-fun OnBackPressedDispatcher.backPresses(lifecycleOwner: LifecycleOwner): Flow<Unit> = channelFlow {
+fun OnBackPressedDispatcher.backPresses(lifecycleOwner: LifecycleOwner): Flow<Unit> = callbackFlow {
     val callback = callback(this, ::trySend)
     addCallback(lifecycleOwner, callback)
     awaitClose { callback.remove() }

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -114,7 +114,7 @@ fun OnBackPressedDispatcher.backProgressed(
  *
  * @param lifecycleOwner The LifecycleOwner which controls when the callback should be invoked
  */
-fun OnBackPressedDispatcher.backProgressed(lifecycleOwner: LifecycleOwner): Flow<Float> = channelFlow {
+fun OnBackPressedDispatcher.backProgressed(lifecycleOwner: LifecycleOwner): Flow<Float> = callbackFlow {
     val callback = callback(this, ::trySend)
     addCallback(lifecycleOwner, callback)
     awaitClose { callback.remove() }

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherOnBackEvents.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherOnBackEvents.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -146,7 +146,7 @@ fun OnBackPressedDispatcher.backEvents(
  *
  * @param lifecycleOwner The LifecycleOwner which controls when the callback should be invoked
  */
-fun OnBackPressedDispatcher.backEvents(lifecycleOwner: LifecycleOwner): Flow<OnBackEvent> = channelFlow {
+fun OnBackPressedDispatcher.backEvents(lifecycleOwner: LifecycleOwner): Flow<OnBackEvent> = callbackFlow {
     val callback = callback(this, ::trySend)
     addCallback(lifecycleOwner, callback)
     awaitClose { callback.remove() }

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ActionMenuViewItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ActionMenuViewItemClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun ActionMenuView.itemClicks(
  * ```
  */
 @CheckResult
-fun ActionMenuView.itemClicks(): Flow<MenuItem> = channelFlow {
+fun ActionMenuView.itemClicks(): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -112,7 +112,7 @@ fun PopupMenu.dismisses(
  * ```
  */
 @CheckResult
-fun PopupMenu.dismisses(): Flow<Unit> = channelFlow {
+fun PopupMenu.dismisses(): Flow<Unit> = callbackFlow {
     setOnDismissListener(listener(this, ::trySend))
     awaitClose { setOnDismissListener(null) }
 }

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuItemClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun PopupMenu.itemClicks(
  * ```
  */
 @CheckResult
-fun PopupMenu.itemClicks(): Flow<MenuItem> = channelFlow {
+fun PopupMenu.itemClicks(): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChangeEvents.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -134,7 +134,7 @@ fun SearchView.queryTextChangeEvents(
  * ```
  */
 @CheckResult
-fun SearchView.queryTextChangeEvents(): InitialValueFlow<SearchViewQueryTextEvent> = channelFlow {
+fun SearchView.queryTextChangeEvents(): InitialValueFlow<SearchViewQueryTextEvent> = callbackFlow {
     setOnQueryTextListener(listener(this, this@queryTextChangeEvents, ::trySend))
     awaitClose { setOnQueryTextListener(null) }
 }.asInitialValueFlow(SearchViewQueryTextEvent(view = this, query, false))

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChanges.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -128,7 +128,7 @@ fun SearchView.queryTextChanges(
  * ```
  */
 @CheckResult
-fun SearchView.queryTextChanges(): InitialValueFlow<CharSequence> = channelFlow {
+fun SearchView.queryTextChanges(): InitialValueFlow<CharSequence> = callbackFlow {
     setOnQueryTextListener(listener(this, ::trySend))
     awaitClose { setOnQueryTextListener(null) }
 }.asInitialValueFlow(query)

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarItemClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun Toolbar.itemClicks(
  * ```
  */
 @CheckResult
-fun Toolbar.itemClicks(): Flow<MenuItem> = channelFlow {
+fun Toolbar.itemClicks(): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarNavigationClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarNavigationClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun Toolbar.navigationClicks(
  * ```
  */
 @CheckResult
-fun Toolbar.navigationClicks(): Flow<Unit> = channelFlow {
+fun Toolbar.navigationClicks(): Flow<Unit> = callbackFlow {
     setNavigationOnClickListener(listener(this, ::trySend))
     awaitClose { setNavigationOnClickListener(null) }
 }

--- a/corbind-core/src/main/kotlin/ru/ldralighieri/corbind/core/NestedScrollViewScrollChangeEvents.kt
+++ b/corbind-core/src/main/kotlin/ru/ldralighieri/corbind/core/NestedScrollViewScrollChangeEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 import ru.ldralighieri.corbind.view.ViewScrollChangeEvent
@@ -115,7 +115,7 @@ fun NestedScrollView.scrollChangeEvents(
  * ```
  */
 @CheckResult
-fun NestedScrollView.scrollChangeEvents(): Flow<ViewScrollChangeEvent> = channelFlow {
+fun NestedScrollView.scrollChangeEvents(): Flow<ViewScrollChangeEvent> = callbackFlow {
     setOnScrollChangeListener(listener(this, ::trySend))
     awaitClose { setOnScrollChangeListener(null as NestedScrollView.OnScrollChangeListener?) }
 }

--- a/corbind-drawerlayout/src/main/kotlin/ru/ldralighieri/corbind/drawerlayout/DrawerLayoutDrawerOpen.kt
+++ b/corbind-drawerlayout/src/main/kotlin/ru/ldralighieri/corbind/drawerlayout/DrawerLayoutDrawerOpen.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -126,7 +126,7 @@ fun DrawerLayout.drawerOpens(
  * @param gravity Gravity of the drawer to check
  */
 @CheckResult
-fun DrawerLayout.drawerOpens(gravity: Int): InitialValueFlow<Boolean> = channelFlow {
+fun DrawerLayout.drawerOpens(gravity: Int): InitialValueFlow<Boolean> = callbackFlow {
     val listener = listener(this, gravity, ::trySend)
     addDrawerListener(listener)
     awaitClose { removeDrawerListener(listener) }

--- a/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
+++ b/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -146,7 +146,7 @@ fun FragmentManager.resultEvents(
 fun FragmentManager.resultEvents(
     requestKey: String,
     lifecycleOwner: LifecycleOwner,
-): Flow<FragmentResultEvent> = channelFlow {
+): Flow<FragmentResultEvent> = callbackFlow {
     val listener = listener(this, ::trySend)
     setFragmentResultListener(requestKey, lifecycleOwner, listener)
     awaitClose { clearFragmentResultListener(requestKey) }

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChangeEvents.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChangeEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -164,7 +164,7 @@ fun SearchBar.searchQueryChangeEvents(
  *      .launchIn(lifecycleScope) // lifecycle-runtime-ktx
  */
 @CheckResult
-fun SearchBar.searchQueryChangeEvents(): Flow<SearchBarSearchQueryEvent> = channelFlow {
+fun SearchBar.searchQueryChangeEvents(): Flow<SearchBarSearchQueryEvent> = callbackFlow {
     setSearchBarListener(listener(this, this@searchQueryChangeEvents, ::trySend))
     awaitClose { setSearchBarListener(null) }
 }

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChanges.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun SearchBar.searchQueryChanges(
  * ```
  */
 @CheckResult
-fun SearchBar.searchQueryChanges(): Flow<String> = channelFlow {
+fun SearchBar.searchQueryChanges(): Flow<String> = callbackFlow {
     setSearchBarListener(listener(this, ::trySend))
     awaitClose { setSearchBarListener(null) }
 }

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchEditTextKeyboardDismisses.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchEditTextKeyboardDismisses.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun SearchEditText.keyboardDismisses(
  * ```
  */
 @CheckResult
-fun SearchEditText.keyboardDismisses(): Flow<Unit> = channelFlow {
+fun SearchEditText.keyboardDismisses(): Flow<Unit> = callbackFlow {
     setOnKeyboardDismissListener(listener(this, ::trySend))
     awaitClose { setOnKeyboardDismissListener(null) }
 }

--- a/corbind-lifecycle/src/main/kotlin/ru/ldralighieri/corbind/lifecycle/LifecycleEvents.kt
+++ b/corbind-lifecycle/src/main/kotlin/ru/ldralighieri/corbind/lifecycle/LifecycleEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun Lifecycle.events(
  * ```
  */
 @CheckResult
-fun Lifecycle.events(): Flow<Lifecycle.Event> = channelFlow {
+fun Lifecycle.events(): Flow<Lifecycle.Event> = callbackFlow {
     val observer = observer(this, ::trySend)
     addObserver(observer)
     awaitClose { removeObserver(observer) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/AppBarLayoutOffsetChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/AppBarLayoutOffsetChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun AppBarLayout.offsetChanges(
  * ```
  */
 @CheckResult
-fun AppBarLayout.offsetChanges(): Flow<Int> = channelFlow {
+fun AppBarLayout.offsetChanges(): Flow<Int> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnOffsetChangedListener(listener)
     awaitClose { removeOnOffsetChangedListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorSlides.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorSlides.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -106,7 +106,7 @@ fun View.slides(
  * ```
  */
 @CheckResult
-fun View.slides(): Flow<Float> = channelFlow {
+fun View.slides(): Flow<Float> = callbackFlow {
     val behavior = getBottomSheetBehavior()
     val callback = callback(this, ::trySend)
     behavior.addBottomSheetCallback(callback)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorStateChanges.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -122,7 +122,7 @@ fun View.stateChanges(
  * ```
  */
 @CheckResult
-fun View.stateChanges(): InitialValueFlow<Int> = channelFlow {
+fun View.stateChanges(): InitialValueFlow<Int> = callbackFlow {
     val behavior = getBottomSheetBehavior()
     val callback = callback(this, ::trySend)
     behavior.addBottomSheetCallback(callback)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun Chip.closeIconClicks(
  * ```
  */
 @CheckResult
-fun Chip.closeIconClicks(): Flow<Unit> = channelFlow {
+fun Chip.closeIconClicks(): Flow<Unit> = callbackFlow {
     setOnCloseIconClickListener(listener(this, ::trySend))
     awaitClose { setOnCloseIconClickListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipGroupCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipGroupCheckedChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -129,7 +129,7 @@ fun ChipGroup.checkedChanges(
  * ```
  */
 @CheckResult
-fun ChipGroup.checkedChanges(): InitialValueFlow<List<Int>> = channelFlow {
+fun ChipGroup.checkedChanges(): InitialValueFlow<List<Int>> = callbackFlow {
     setOnCheckedStateChangeListener(listener(this, ::trySend))
     awaitClose { setOnCheckedStateChangeListener(null) }
 }.asInitialValueFlow(checkedChipIds)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideBottomViewOnScrollBehaviorScrollStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideBottomViewOnScrollBehaviorScrollStateChanges.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -132,7 +132,7 @@ fun View.bottomViewScrollStateChanges(
     replaceWith = ReplaceWith("hideOnScrollStateChanges()"),
 )
 @CheckResult
-fun View.bottomViewScrollStateChanges(): Flow<Int> = channelFlow {
+fun View.bottomViewScrollStateChanges(): Flow<Int> = callbackFlow {
     val behavior = getBehavior()
     val listener = listener(this, ::trySend)
     behavior.addOnScrollStateChangedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideViewOnScrollBehaviorScrollStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideViewOnScrollBehaviorScrollStateChanges.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -114,7 +114,7 @@ fun View.hideOnScrollStateChanges(
  * ```
  */
 @CheckResult
-fun View.hideOnScrollStateChanges(): Flow<Int> = channelFlow {
+fun View.hideOnScrollStateChanges(): Flow<Int> = callbackFlow {
     val behavior = getBehavior()
     val listener = listener(this, ::trySend)
     behavior.addOnScrollStateChangedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaskableFrameLayoutMaskChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaskableFrameLayoutMaskChanges.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -111,7 +111,7 @@ fun MaskableFrameLayout.maskChanges(
  * ```
  */
 @CheckResult
-fun MaskableFrameLayout.maskChanges() = channelFlow {
+fun MaskableFrameLayout.maskChanges() = callbackFlow {
     setOnMaskChangedListener(listener(this, ::trySend))
     awaitClose { setOnMaskChangedListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonCheckedChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -127,7 +127,7 @@ fun MaterialButton.checkedChanges(
  * ```
  */
 @CheckResult
-fun MaterialButton.checkedChanges(): InitialValueFlow<Boolean> = channelFlow {
+fun MaterialButton.checkedChanges(): InitialValueFlow<Boolean> = callbackFlow {
     checkCheckableState(this@checkedChanges)
     val listener = listener(this, ::trySend)
     addOnCheckedChangeListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -122,7 +122,7 @@ fun MaterialButtonToggleGroup.buttonCheckedChangeEvents(
  * ```
  */
 @CheckResult
-fun MaterialButtonToggleGroup.buttonCheckedChangeEvents(): Flow<MaterialButtonCheckedChangeEvent> = channelFlow {
+fun MaterialButtonToggleGroup.buttonCheckedChangeEvents(): Flow<MaterialButtonCheckedChangeEvent> = callbackFlow {
     checkSelectionMode(this@buttonCheckedChangeEvents)
     val listener = listener(this, ::trySend)
     addOnButtonCheckedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChanges.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -138,7 +138,7 @@ fun MaterialButtonToggleGroup.buttonCheckedChanges(
  * ```
  */
 @CheckResult
-fun MaterialButtonToggleGroup.buttonCheckedChanges(): InitialValueFlow<Int> = channelFlow {
+fun MaterialButtonToggleGroup.buttonCheckedChanges(): InitialValueFlow<Int> = callbackFlow {
     checkSelectionMode(this@buttonCheckedChanges)
     val listener = listener(this, ::trySend)
     addOnButtonCheckedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -127,7 +127,7 @@ fun MaterialCardView.checkedChanges(
  * ```
  */
 @CheckResult
-fun MaterialCardView.checkedChanges(): InitialValueFlow<Boolean> = channelFlow {
+fun MaterialCardView.checkedChanges(): InitialValueFlow<Boolean> = callbackFlow {
     checkCheckableState(this@checkedChanges)
     setOnCheckedChangeListener(listener(this, ::trySend))
     awaitClose { setOnCheckedChangeListener(null) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerCancels.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerCancels.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun <S> MaterialDatePicker<S>.cancels(
  * ```
  */
 @CheckResult
-fun <S> MaterialDatePicker<S>.cancels(): Flow<Unit> = channelFlow {
+fun <S> MaterialDatePicker<S>.cancels(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnCancelListener(listener)
     awaitClose { removeOnCancelListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerDismisses.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -106,7 +106,7 @@ fun <S> MaterialDatePicker<S>.dismisses(
  * ```
  */
 @CheckResult
-fun <S> MaterialDatePicker<S>.dismisses(): Flow<Unit> = channelFlow {
+fun <S> MaterialDatePicker<S>.dismisses(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnDismissListener(listener)
     awaitClose { removeOnDismissListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerNegativeClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerNegativeClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun <S> MaterialDatePicker<S>.negativeClicks(
  * ```
  */
 @CheckResult
-fun <S> MaterialDatePicker<S>.negativeClicks(): Flow<Unit> = channelFlow {
+fun <S> MaterialDatePicker<S>.negativeClicks(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnNegativeButtonClickListener(listener)
     awaitClose { removeOnNegativeButtonClickListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerPositiveClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerPositiveClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun <S> MaterialDatePicker<S>.positiveClicks(
  * ```
  */
 @CheckResult
-fun <S> MaterialDatePicker<S>.positiveClicks(): Flow<S> = channelFlow {
+fun <S> MaterialDatePicker<S>.positiveClicks(): Flow<S> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnPositiveButtonClickListener(listener)
     awaitClose { removeOnPositiveButtonClickListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerCancels.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerCancels.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun MaterialTimePicker.cancels(
  * ```
  */
 @CheckResult
-fun MaterialTimePicker.cancels(): Flow<Unit> = channelFlow {
+fun MaterialTimePicker.cancels(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnCancelListener(listener)
     awaitClose { removeOnCancelListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerDismisses.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -106,7 +106,7 @@ fun MaterialTimePicker.dismisses(
  * ```
  */
 @CheckResult
-fun MaterialTimePicker.dismisses(): Flow<Unit> = channelFlow {
+fun MaterialTimePicker.dismisses(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnDismissListener(listener)
     awaitClose { removeOnDismissListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerNegativeClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerNegativeClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun MaterialTimePicker.negativeClicks(
  * ```
  */
 @CheckResult
-fun MaterialTimePicker.negativeClicks(): Flow<Unit> = channelFlow {
+fun MaterialTimePicker.negativeClicks(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnNegativeButtonClickListener(listener)
     awaitClose { removeOnNegativeButtonClickListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerPositiveClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerPositiveClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun MaterialTimePicker.positiveClicks(
  * ```
  */
 @CheckResult
-fun MaterialTimePicker.positiveClicks(): Flow<Unit> = channelFlow {
+fun MaterialTimePicker.positiveClicks(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnPositiveButtonClickListener(listener)
     awaitClose { removeOnPositiveButtonClickListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemReselections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemReselections.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun NavigationBarView.itemReselections(
  * ```
  */
 @CheckResult
-fun NavigationBarView.itemReselections(): Flow<MenuItem> = channelFlow {
+fun NavigationBarView.itemReselections(): Flow<MenuItem> = callbackFlow {
     setOnItemReselectedListener(listener(this, ::trySend))
     awaitClose { setOnItemReselectedListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemSelections.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -127,7 +127,7 @@ fun NavigationBarView.itemSelections(
  * ```
  */
 @CheckResult
-fun NavigationBarView.itemSelections(): Flow<MenuItem> = channelFlow {
+fun NavigationBarView.itemSelections(): Flow<MenuItem> = callbackFlow {
     setInitialValue(this@itemSelections, ::trySend)
     setOnItemSelectedListener(listener(this, ::trySend))
     awaitClose { setOnItemSelectedListener(null) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationViewItemSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationViewItemSelections.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -127,7 +127,7 @@ fun NavigationView.itemSelections(
  * ```
  */
 @CheckResult
-fun NavigationView.itemSelections(): Flow<MenuItem> = channelFlow {
+fun NavigationView.itemSelections(): Flow<MenuItem> = callbackFlow {
     setInitialValue(this@itemSelections, ::trySend)
     setNavigationItemSelectedListener(listener(this, ::trySend))
     awaitClose { setNavigationItemSelectedListener(null) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderTouches.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderTouches.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun RangeSlider.touches(
  * ```
  */
 @CheckResult
-fun RangeSlider.touches(): Flow<Boolean> = channelFlow {
+fun RangeSlider.touches(): Flow<Boolean> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnSliderTouchListener(listener)
     awaitClose { removeOnSliderTouchListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -128,7 +128,7 @@ fun RangeSlider.valuesChangeEvents(
  * ```
  */
 @CheckResult
-fun RangeSlider.valuesChangeEvents(): InitialValueFlow<RangeSliderChangeEvent> = channelFlow {
+fun RangeSlider.valuesChangeEvents(): InitialValueFlow<RangeSliderChangeEvent> = callbackFlow {
     val listener = listener(this, ::trySend).apply { previousValues = values }
     addOnChangeListener(listener)
     awaitClose { removeOnChangeListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -117,7 +117,7 @@ fun RangeSlider.valuesChanges(
  * ```
  */
 @CheckResult
-fun RangeSlider.valuesChanges(): InitialValueFlow<List<Float>> = channelFlow {
+fun RangeSlider.valuesChanges(): InitialValueFlow<List<Float>> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnChangeListener(listener)
     awaitClose { removeOnChangeListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchBarNavigationClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchBarNavigationClicks.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun SearchBar.navigationClicks(
  */
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 @CheckResult
-fun SearchBar.navigationClicks(): Flow<Unit> = channelFlow {
+fun SearchBar.navigationClicks(): Flow<Unit> = callbackFlow {
     setNavigationOnClickListener(listener(this, ::trySend))
     awaitClose { setNavigationOnClickListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChangeEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun SearchView.transitionStateChangeEvents(
  * ```
  */
 @CheckResult
-fun SearchView.transitionStateChangeEvents(): Flow<SearchViewTransitionStateChangeEvent> = channelFlow {
+fun SearchView.transitionStateChangeEvents(): Flow<SearchViewTransitionStateChangeEvent> = callbackFlow {
     val listener = listener(this, ::trySend)
     addTransitionListener(listener)
     awaitClose { removeTransitionListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun SearchView.transitionStateChanges(
  * ```
  */
 @CheckResult
-fun SearchView.transitionStateChanges(): Flow<SearchView.TransitionState> = channelFlow {
+fun SearchView.transitionStateChanges(): Flow<SearchView.TransitionState> = callbackFlow {
     val listener = listener(this, ::trySend)
     addTransitionListener(listener)
     awaitClose { removeTransitionListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorSlides.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorSlides.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -107,7 +107,7 @@ fun View.sideSheetSlides(
  * ```
  */
 @CheckResult
-fun View.sideSheetSlides(): Flow<Float> = channelFlow {
+fun View.sideSheetSlides(): Flow<Float> = callbackFlow {
     val behavior = getSideSheetBehavior()
     val callback = callback(this, ::trySend)
     behavior.addCallback(callback)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorStateChanges.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -123,7 +123,7 @@ fun View.sideSheetStateChanges(
  * ```
  */
 @CheckResult
-fun View.sideSheetStateChanges(): InitialValueFlow<Int> = channelFlow {
+fun View.sideSheetStateChanges(): InitialValueFlow<Int> = callbackFlow {
     val behavior = getSideSheetBehavior()
     val callback = callback(this, ::trySend)
     behavior.addCallback(callback)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderTouches.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderTouches.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun Slider.touches(
  * ```
  */
 @CheckResult
-fun Slider.touches(): Flow<Boolean> = channelFlow {
+fun Slider.touches(): Flow<Boolean> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnSliderTouchListener(listener)
     awaitClose { removeOnSliderTouchListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -125,7 +125,7 @@ fun Slider.valueChangeEvents(
  * ```
  */
 @CheckResult
-fun Slider.valueChangeEvents(): InitialValueFlow<SliderChangeEvent> = channelFlow {
+fun Slider.valueChangeEvents(): InitialValueFlow<SliderChangeEvent> = callbackFlow {
     val listener = listener(this, ::trySend).apply { previousValue = value }
     addOnChangeListener(listener)
     awaitClose { removeOnChangeListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -117,7 +117,7 @@ fun Slider.valueChanges(
  * ```
  */
 @CheckResult
-fun Slider.valueChanges(): InitialValueFlow<Float> = channelFlow {
+fun Slider.valueChanges(): InitialValueFlow<Float> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnChangeListener(listener)
     awaitClose { removeOnChangeListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarDismisses.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun Snackbar.dismisses(
  * ```
  */
 @CheckResult
-fun Snackbar.dismisses(): Flow<Int> = channelFlow {
+fun Snackbar.dismisses(): Flow<Int> = callbackFlow {
     val callback = callback(this, ::trySend)
     addCallback(callback)
     awaitClose { removeCallback(callback) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarShown.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarShown.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun Snackbar.shown(
  * ```
  */
 @CheckResult
-fun Snackbar.shown(): Flow<Snackbar> = channelFlow {
+fun Snackbar.shown(): Flow<Snackbar> = callbackFlow {
     val callback = callback(this, ::trySend)
     addCallback(callback)
     awaitClose { removeCallback(callback) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDesmisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDesmisses.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -115,7 +115,7 @@ fun View.dismisses(
  * ```
  */
 @CheckResult
-fun View.dismisses(): Flow<View> = channelFlow {
+fun View.dismisses(): Flow<View> = callbackFlow {
     val behavior = getBehavior(this@dismisses)
     behavior.listener = listener(this, ::trySend)
     awaitClose { behavior.setListener(null) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDragStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDragStateChanges.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -114,7 +114,7 @@ fun View.dragStateChanges(
  * ```
  */
 @CheckResult
-fun View.dragStateChanges(): Flow<Int> = channelFlow {
+fun View.dragStateChanges(): Flow<Int> = callbackFlow {
     val behavior = getBehavior(this@dragStateChanges)
     behavior.listener = listener(this, ::trySend)
     awaitClose { behavior.setListener(null) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelectionEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelectionEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -167,7 +167,7 @@ fun TabLayout.selectionEvents(
  * ```
  */
 @CheckResult
-fun TabLayout.selectionEvents(): Flow<TabLayoutSelectionEvent> = channelFlow {
+fun TabLayout.selectionEvents(): Flow<TabLayoutSelectionEvent> = callbackFlow {
     setInitialValue(this@selectionEvents, ::trySend)
     val listener = listener(this, this@selectionEvents, ::trySend)
     addOnTabSelectedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelections.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -116,7 +116,7 @@ fun TabLayout.selections(
  * ```
  */
 @CheckResult
-fun TabLayout.selections(): Flow<TabLayout.Tab> = channelFlow {
+fun TabLayout.selections(): Flow<TabLayout.Tab> = callbackFlow {
     setInitialValue(this@selections, ::trySend)
     val listener = listener(this, ::trySend)
     addOnTabSelectedListener(listener)

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -108,7 +108,7 @@ fun TextInputLayout.endIconChanges(
  * ```
  */
 @CheckResult
-fun TextInputLayout.endIconChanges(): Flow<Int> = channelFlow {
+fun TextInputLayout.endIconChanges(): Flow<Int> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnEndIconChangedListener(listener)
     awaitClose { removeOnEndIconChangedListener(listener) }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun TextInputLayout.endIconClicks(
  * ```
  */
 @CheckResult
-fun TextInputLayout.endIconClicks(): Flow<Unit> = channelFlow {
+fun TextInputLayout.endIconClicks(): Flow<Unit> = callbackFlow {
     setEndIconOnClickListener(listener(this, ::trySend))
     awaitClose { setEndIconOnClickListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconLongClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconLongClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -128,7 +128,7 @@ fun TextInputLayout.endIconLongClicks(
 @CheckResult
 fun TextInputLayout.endIconLongClicks(
     handled: () -> Boolean = AlwaysTrue,
-): Flow<Unit> = channelFlow {
+): Flow<Unit> = callbackFlow {
     setEndIconOnLongClickListener(listener(this, handled, ::trySend))
     awaitClose { setEndIconOnLongClickListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun TextInputLayout.startIconClicks(
  * ```
  */
 @CheckResult
-fun TextInputLayout.startIconClicks(): Flow<Unit> = channelFlow {
+fun TextInputLayout.startIconClicks(): Flow<Unit> = callbackFlow {
     setStartIconOnClickListener(listener(this, ::trySend))
     awaitClose { setStartIconOnClickListener(null) }
 }

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconLongClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconLongClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -128,7 +128,7 @@ fun TextInputLayout.startIconLongClicks(
 @CheckResult
 fun TextInputLayout.startIconLongClicks(
     handled: () -> Boolean = AlwaysTrue,
-): Flow<Unit> = channelFlow {
+): Flow<Unit> = callbackFlow {
     setStartIconOnLongClickListener(listener(this, handled, ::trySend))
     awaitClose { setStartIconOnLongClickListener(null) }
 }

--- a/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChangeEvents.kt
+++ b/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChangeEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -115,7 +115,7 @@ fun NavController.destinationChangeEvents(
  * ```
  */
 @CheckResult
-fun NavController.destinationChangeEvents(): Flow<NavControllerOnDestinationChangeEvent> = channelFlow {
+fun NavController.destinationChangeEvents(): Flow<NavControllerOnDestinationChangeEvent> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnDestinationChangedListener(listener)
     awaitClose { removeOnDestinationChangedListener(listener) }

--- a/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChanges.kt
+++ b/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChanges.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -103,7 +103,7 @@ fun NavController.destinationChanges(
  * ```
  */
 @CheckResult
-fun NavController.destinationChanges(): Flow<NavDestination> = channelFlow {
+fun NavController.destinationChanges(): Flow<NavDestination> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnDestinationChangedListener(listener)
     awaitClose { removeOnDestinationChangedListener(listener) }

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerAdapterDataChanges.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerAdapterDataChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -117,7 +117,7 @@ fun <T : RecyclerView.Adapter<out RecyclerView.ViewHolder>> T.dataChanges(
  * ```
  */
 @CheckResult
-fun <T : RecyclerView.Adapter<out RecyclerView.ViewHolder>> T.dataChanges(): InitialValueFlow<T> = channelFlow {
+fun <T : RecyclerView.Adapter<out RecyclerView.ViewHolder>> T.dataChanges(): InitialValueFlow<T> = callbackFlow {
     val dataObserver = observer(this, this@dataChanges, ::trySend)
     registerAdapterDataObserver(dataObserver)
     awaitClose { unregisterAdapterDataObserver(dataObserver) }

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewChildAttachStateChangeEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewChildAttachStateChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -151,7 +151,7 @@ fun RecyclerView.childAttachStateChangeEvents(
  * ```
  */
 @CheckResult
-fun RecyclerView.childAttachStateChangeEvents(): Flow<RecyclerViewChildAttachStateChangeEvent> = channelFlow {
+fun RecyclerView.childAttachStateChangeEvents(): Flow<RecyclerViewChildAttachStateChangeEvent> = callbackFlow {
     val listener = listener(this, this@childAttachStateChangeEvents, ::trySend)
     addOnChildAttachStateChangeListener(listener)
     awaitClose { removeOnChildAttachStateChangeListener(listener) }

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewFlingEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewFlingEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun RecyclerView.flingEvents(
  * ```
  */
 @CheckResult
-fun RecyclerView.flingEvents(): Flow<RecyclerViewFlingEvent> = channelFlow {
+fun RecyclerView.flingEvents(): Flow<RecyclerViewFlingEvent> = callbackFlow {
     onFlingListener = listener(this, this@flingEvents, ::trySend)
     awaitClose { onFlingListener = null }
 }

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -109,7 +109,7 @@ fun RecyclerView.scrollEvents(
  * ```
  */
 @CheckResult
-fun RecyclerView.scrollEvents(): Flow<RecyclerViewScrollEvent> = channelFlow {
+fun RecyclerView.scrollEvents(): Flow<RecyclerViewScrollEvent> = callbackFlow {
     val scrollListener = listener(this, ::trySend)
     addOnScrollListener(scrollListener)
     awaitClose { removeOnScrollListener(scrollListener) }

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollStateChanges.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollStateChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun RecyclerView.scrollStateChanges(
  * ```
  */
 @CheckResult
-fun RecyclerView.scrollStateChanges(): Flow<Int> = channelFlow {
+fun RecyclerView.scrollStateChanges(): Flow<Int> = callbackFlow {
     val scrollListener = listener(this, ::trySend)
     addOnScrollListener(scrollListener)
     awaitClose { removeOnScrollListener(scrollListener) }

--- a/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutPaneOpens.kt
+++ b/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutPaneOpens.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -122,7 +122,7 @@ fun SlidingPaneLayout.panelOpens(
  * ```
  */
 @CheckResult
-fun SlidingPaneLayout.panelOpens(): InitialValueFlow<Boolean> = channelFlow {
+fun SlidingPaneLayout.panelOpens(): InitialValueFlow<Boolean> = callbackFlow {
     val listener = listener(this, ::trySend)
     addPanelSlideListener(listener)
     awaitClose { removePanelSlideListener(listener) }

--- a/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutSlides.kt
+++ b/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutSlides.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -107,7 +107,7 @@ fun SlidingPaneLayout.panelSlides(
  * ```
  */
 @CheckResult
-fun SlidingPaneLayout.panelSlides(): Flow<Float> = channelFlow {
+fun SlidingPaneLayout.panelSlides(): Flow<Float> = callbackFlow {
     val listener = listener(this, ::trySend)
     addPanelSlideListener(listener)
     awaitClose { removePanelSlideListener(listener) }

--- a/corbind-swiperefreshlayout/src/main/kotlin/ru/ldralighieri/corbind/swiperefreshlayout/SwipeRefreshLayoutRefreshes.kt
+++ b/corbind-swiperefreshlayout/src/main/kotlin/ru/ldralighieri/corbind/swiperefreshlayout/SwipeRefreshLayoutRefreshes.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -112,7 +112,7 @@ fun SwipeRefreshLayout.refreshes(
  * ```
  */
 @CheckResult
-fun SwipeRefreshLayout.refreshes(): Flow<Unit> = channelFlow {
+fun SwipeRefreshLayout.refreshes(): Flow<Unit> = callbackFlow {
     setOnRefreshListener(listener(this, ::trySend))
     awaitClose { setOnRefreshListener(null) }
 }

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollEvents.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -110,7 +110,7 @@ fun ViewPager.pageScrollEvents(
  * ```
  */
 @CheckResult
-fun ViewPager.pageScrollEvents(): Flow<ViewPagerPageScrollEvent> = channelFlow {
+fun ViewPager.pageScrollEvents(): Flow<ViewPagerPageScrollEvent> = callbackFlow {
     val listener = listener(this, this@pageScrollEvents, ::trySend)
     addOnPageChangeListener(listener)
     awaitClose { removeOnPageChangeListener(listener) }

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollStateChanges.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollStateChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun ViewPager.pageScrollStateChanges(
  * ```
  */
 @CheckResult
-fun ViewPager.pageScrollStateChanges(): Flow<Int> = channelFlow {
+fun ViewPager.pageScrollStateChanges(): Flow<Int> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnPageChangeListener(listener)
     awaitClose { removeOnPageChangeListener(listener) }

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageSelections.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageSelections.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -118,7 +118,7 @@ fun ViewPager.pageSelections(
  * ```
  */
 @CheckResult
-fun ViewPager.pageSelections(): InitialValueFlow<Int> = channelFlow {
+fun ViewPager.pageSelections(): InitialValueFlow<Int> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnPageChangeListener(listener)
     awaitClose { removeOnPageChangeListener(listener) }

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollEvents.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -110,7 +110,7 @@ fun ViewPager2.pageScrollEvents(
  * ```
  */
 @CheckResult
-fun ViewPager2.pageScrollEvents(): Flow<ViewPager2PageScrollEvent> = channelFlow {
+fun ViewPager2.pageScrollEvents(): Flow<ViewPager2PageScrollEvent> = callbackFlow {
     val callback = callback(this, this@pageScrollEvents, ::trySend)
     registerOnPageChangeCallback(callback)
     awaitClose { unregisterOnPageChangeCallback(callback) }

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollStateChanges.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollStateChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun ViewPager2.pageScrollStateChanges(
  * ```
  */
 @CheckResult
-fun ViewPager2.pageScrollStateChanges(): Flow<Int> = channelFlow {
+fun ViewPager2.pageScrollStateChanges(): Flow<Int> = callbackFlow {
     val callback = callback(this, ::trySend)
     registerOnPageChangeCallback(callback)
     awaitClose { unregisterOnPageChangeCallback(callback) }

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageSelections.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageSelections.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -117,7 +117,7 @@ fun ViewPager2.pageSelections(
  * ```
  */
 @CheckResult
-fun ViewPager2.pageSelections(): InitialValueFlow<Int> = channelFlow {
+fun ViewPager2.pageSelections(): InitialValueFlow<Int> = callbackFlow {
     val callback = callback(this, ::trySend)
     registerOnPageChangeCallback(callback)
     awaitClose { unregisterOnPageChangeCallback(callback) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/app/DatePickerDialogDateSetEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/app/DatePickerDialogDateSetEvents.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -128,7 +128,7 @@ fun DatePickerDialog.dateSetEvents(
  */
 @RequiresApi(Build.VERSION_CODES.N)
 @CheckResult
-fun DatePickerDialog.dateSetEvents(): Flow<DatePickerDialogSetEvent> = channelFlow {
+fun DatePickerDialog.dateSetEvents(): Flow<DatePickerDialogSetEvent> = callbackFlow {
     setOnDateSetListener(listener(this, ::trySend))
     awaitClose { setOnDateSetListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/content/ContextReceivesBroadcast.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/content/ContextReceivesBroadcast.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -135,7 +135,7 @@ fun Context.receivesBroadcast(
  *
  * @param intentFilter Selects the Intent broadcasts to be received
  */
-fun Context.receivesBroadcast(intentFilter: IntentFilter): Flow<Intent> = channelFlow {
+fun Context.receivesBroadcast(intentFilter: IntentFilter): Flow<Intent> = callbackFlow {
     val receiver = receiver(this, ::trySend)
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemActionViewEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemActionViewEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -166,7 +166,7 @@ fun MenuItem.actionViewEvents(
 @CheckResult
 fun MenuItem.actionViewEvents(
     handled: (MenuItemActionViewEvent) -> Boolean = AlwaysTrue,
-): Flow<MenuItemActionViewEvent> = channelFlow {
+): Flow<MenuItemActionViewEvent> = callbackFlow {
     setOnActionExpandListener(listener(this, handled, ::trySend))
     awaitClose { setOnActionExpandListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemClicks.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -127,7 +127,7 @@ fun MenuItem.clicks(
 @CheckResult
 fun MenuItem.clicks(
     handled: (MenuItem) -> Boolean = AlwaysTrue,
-): Flow<MenuItem> = channelFlow {
+): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, handled, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttachEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttachEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -141,7 +141,7 @@ fun View.attachEvents(
  * ```
  */
 @CheckResult
-fun View.attachEvents(): Flow<ViewAttachEvent> = channelFlow {
+fun View.attachEvents(): Flow<ViewAttachEvent> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnAttachStateChangeListener(listener)
     awaitClose { removeOnAttachStateChangeListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttaches.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttaches.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -102,7 +102,7 @@ fun View.attaches(
  * ```
  */
 @CheckResult
-fun View.attaches(): Flow<Unit> = channelFlow {
+fun View.attaches(): Flow<Unit> = callbackFlow {
     val listener = listener(this, true, ::trySend)
     addOnAttachStateChangeListener(listener)
     awaitClose { removeOnAttachStateChangeListener(listener) }
@@ -180,7 +180,7 @@ fun View.detaches(
  * ```
  */
 @CheckResult
-fun View.detaches(): Flow<Unit> = channelFlow {
+fun View.detaches(): Flow<Unit> = callbackFlow {
     val listener = listener(this, false, ::trySend)
     addOnAttachStateChangeListener(listener)
     awaitClose { removeOnAttachStateChangeListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewClicks.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -111,7 +111,7 @@ fun View.clicks(
  * ```
  */
 @CheckResult
-fun View.clicks(): Flow<Unit> = channelFlow {
+fun View.clicks(): Flow<Unit> = callbackFlow {
     setOnClickListener(listener(this, ::trySend))
     awaitClose { setOnClickListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewDrags.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewDrags.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -125,7 +125,7 @@ fun View.drags(
 @CheckResult
 fun View.drags(
     handled: (DragEvent) -> Boolean = AlwaysTrue,
-): Flow<DragEvent> = channelFlow {
+): Flow<DragEvent> = callbackFlow {
     setOnDragListener(listener(this, handled, ::trySend))
     awaitClose { setOnDragListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewFocusChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewFocusChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -127,7 +127,7 @@ fun View.focusChanges(
  * ```
  */
 @CheckResult
-fun View.focusChanges(): InitialValueFlow<Boolean> = channelFlow {
+fun View.focusChanges(): InitialValueFlow<Boolean> = callbackFlow {
     onFocusChangeListener = listener(this, ::trySend)
     awaitClose { onFocusChangeListener = null }
 }.asInitialValueFlow(hasFocus())

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewGroupHierarchyChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewGroupHierarchyChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -155,7 +155,7 @@ fun ViewGroup.changeEvents(
  * ```
  */
 @CheckResult
-fun ViewGroup.changeEvents(): Flow<ViewGroupHierarchyChangeEvent> = channelFlow {
+fun ViewGroup.changeEvents(): Flow<ViewGroupHierarchyChangeEvent> = callbackFlow {
     setOnHierarchyChangeListener(listener(this, this@changeEvents, ::trySend))
     awaitClose { setOnHierarchyChangeListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewHovers.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewHovers.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -125,7 +125,7 @@ fun View.hovers(
  * [View.OnHoverListener]
  */
 @CheckResult
-fun View.hovers(handled: (MotionEvent) -> Boolean = AlwaysTrue): Flow<MotionEvent> = channelFlow {
+fun View.hovers(handled: (MotionEvent) -> Boolean = AlwaysTrue): Flow<MotionEvent> = callbackFlow {
     setOnHoverListener(listener(this, handled, ::trySend))
     awaitClose { setOnHoverListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewKeys.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewKeys.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -123,7 +123,7 @@ fun View.keys(
  * [View.OnKeyListener]
  */
 @CheckResult
-fun View.keys(handled: (KeyEvent) -> Boolean = AlwaysTrue): Flow<KeyEvent> = channelFlow {
+fun View.keys(handled: (KeyEvent) -> Boolean = AlwaysTrue): Flow<KeyEvent> = callbackFlow {
     setOnKeyListener(listener(this, handled, ::trySend))
     awaitClose { setOnKeyListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChangeEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -115,7 +115,7 @@ fun View.layoutChangeEvents(
  * ```
  */
 @CheckResult
-fun View.layoutChangeEvents(): Flow<ViewLayoutChangeEvent> = channelFlow {
+fun View.layoutChangeEvents(): Flow<ViewLayoutChangeEvent> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnLayoutChangeListener(listener)
     awaitClose { removeOnLayoutChangeListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -100,7 +100,7 @@ fun View.layoutChanges(
  * ```
  */
 @CheckResult
-fun View.layoutChanges(): Flow<Unit> = channelFlow {
+fun View.layoutChanges(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     addOnLayoutChangeListener(listener)
     awaitClose { removeOnLayoutChangeListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLongClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLongClicks.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -127,7 +127,7 @@ fun View.longClicks(
 @CheckResult
 fun View.longClicks(
     handled: () -> Boolean = AlwaysTrue,
-): Flow<Unit> = channelFlow {
+): Flow<Unit> = callbackFlow {
     setOnLongClickListener(listener(this, handled, ::trySend))
     awaitClose { setOnLongClickListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewScrollChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewScrollChangeEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -127,7 +127,7 @@ fun View.scrollChangeEvents(
  */
 @RequiresApi(Build.VERSION_CODES.M)
 @CheckResult
-fun View.scrollChangeEvents(): Flow<ViewScrollChangeEvent> = channelFlow {
+fun View.scrollChangeEvents(): Flow<ViewScrollChangeEvent> = callbackFlow {
     setOnScrollChangeListener(listener(this, ::trySend))
     awaitClose { setOnScrollChangeListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewSystemUiVisibilityChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewSystemUiVisibilityChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -160,7 +160,7 @@ fun View.systemUiVisibilityChanges(
     ),
 )
 @CheckResult
-fun View.systemUiVisibilityChanges(): Flow<Int> = channelFlow {
+fun View.systemUiVisibilityChanges(): Flow<Int> = callbackFlow {
     setOnSystemUiVisibilityChangeListener(listener(this, ::trySend))
     awaitClose { setOnSystemUiVisibilityChangeListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTouches.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTouches.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -128,7 +128,7 @@ fun View.touches(
 @CheckResult
 fun View.touches(
     handled: (MotionEvent) -> Boolean = AlwaysTrue,
-): Flow<MotionEvent> = channelFlow {
+): Flow<MotionEvent> = callbackFlow {
     setOnTouchListener(listener(this, handled, ::trySend))
     awaitClose { setOnTouchListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverDraws.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverDraws.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -109,7 +109,7 @@ fun View.draws(
  */
 @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
 @CheckResult
-fun View.draws(): Flow<Unit> = channelFlow {
+fun View.draws(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     viewTreeObserver.addOnDrawListener(listener)
     awaitClose { viewTreeObserver.removeOnDrawListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -109,7 +109,7 @@ fun View.globalLayouts(
  * ```
  */
 @CheckResult
-fun View.globalLayouts(): Flow<Unit> = channelFlow {
+fun View.globalLayouts(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
     viewTreeObserver.addOnGlobalLayoutListener(listener)
     awaitClose {

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverPreDraws.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverPreDraws.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun View.preDraws(
 @CheckResult
 fun View.preDraws(
     proceedDrawingPass: () -> Boolean,
-): Flow<Unit> = channelFlow {
+): Flow<Unit> = callbackFlow {
     val listener = listener(this, proceedDrawingPass, ::trySend)
     viewTreeObserver.addOnPreDrawListener(listener)
     awaitClose { viewTreeObserver.removeOnPreDrawListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewWindowInsetsApplyEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewWindowInsetsApplyEvents.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -128,7 +128,7 @@ fun View.windowInsetsApplyEvents(
  */
 @RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
 @CheckResult
-fun View.windowInsetsApplyEvents(): Flow<WindowInsetsEvent> = channelFlow {
+fun View.windowInsetsApplyEvents(): Flow<WindowInsetsEvent> = callbackFlow {
     setOnApplyWindowInsetsListener(listener(this, ::trySend))
     awaitClose { setOnApplyWindowInsetsListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AbsListViewScrollEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AbsListViewScrollEvents.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -121,7 +121,7 @@ fun AbsListView.scrollEvents(
  * ```
  */
 @CheckResult
-fun AbsListView.scrollEvents(): Flow<AbsListViewScrollEvent> = channelFlow {
+fun AbsListView.scrollEvents(): Flow<AbsListViewScrollEvent> = callbackFlow {
     setOnScrollListener(listener(this, ::trySend))
     awaitClose { setOnScrollListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterDataChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterDataChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -118,7 +118,7 @@ fun <T : Adapter> T.dataChanges(
  * ```
  */
 @CheckResult
-fun <T : Adapter> T.dataChanges(): InitialValueFlow<T> = channelFlow {
+fun <T : Adapter> T.dataChanges(): InitialValueFlow<T> = callbackFlow {
     val dataSetObserver = observer(this, this@dataChanges, ::trySend)
     registerDataSetObserver(dataSetObserver)
     awaitClose { unregisterDataSetObserver(dataSetObserver) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClickEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -122,7 +122,7 @@ fun <T : Adapter> AdapterView<T>.itemClickEvents(
  * ```
  */
 @CheckResult
-fun <T : Adapter> AdapterView<T>.itemClickEvents(): Flow<AdapterViewItemClickEvent> = channelFlow {
+fun <T : Adapter> AdapterView<T>.itemClickEvents(): Flow<AdapterViewItemClickEvent> = callbackFlow {
     onItemClickListener = listener(this, ::trySend)
     awaitClose { onItemClickListener = null }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClicks.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -114,7 +114,7 @@ fun <T : Adapter> AdapterView<T>.itemClicks(
  * ```
  */
 @CheckResult
-fun <T : Adapter> AdapterView<T>.itemClicks(): Flow<Int> = channelFlow {
+fun <T : Adapter> AdapterView<T>.itemClicks(): Flow<Int> = callbackFlow {
     onItemClickListener = listener(this, ::trySend)
     awaitClose { onItemClickListener = null }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClickEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -138,7 +138,7 @@ fun <T : Adapter> AdapterView<T>.itemLongClickEvents(
 @CheckResult
 fun <T : Adapter> AdapterView<T>.itemLongClickEvents(
     handled: (AdapterViewItemLongClickEvent) -> Boolean = AlwaysTrue,
-): Flow<AdapterViewItemLongClickEvent> = channelFlow {
+): Flow<AdapterViewItemLongClickEvent> = callbackFlow {
     onItemLongClickListener = listener(this, handled, ::trySend)
     awaitClose { onItemLongClickListener = null }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClicks.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -129,7 +129,7 @@ fun <T : Adapter> AdapterView<T>.itemLongClicks(
 @CheckResult
 fun <T : Adapter> AdapterView<T>.itemLongClicks(
     handled: () -> Boolean = AlwaysTrue,
-): Flow<Int> = channelFlow {
+): Flow<Int> = callbackFlow {
     onItemLongClickListener = listener(this, handled, ::trySend)
     awaitClose { onItemLongClickListener = null }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemSelections.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemSelections.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -131,7 +131,7 @@ fun <T : Adapter> AdapterView<T>.itemSelections(
  * ```
  */
 @CheckResult
-fun <T : Adapter> AdapterView<T>.itemSelections(): InitialValueFlow<Int> = channelFlow {
+fun <T : Adapter> AdapterView<T>.itemSelections(): InitialValueFlow<Int> = callbackFlow {
     onItemSelectedListener = listener(this, ::trySend)
     awaitClose { onItemSelectedListener = null }
 }.asInitialValueFlow(selectedItemPosition)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewSelectionEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewSelectionEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -170,7 +170,7 @@ fun <T : Adapter> AdapterView<T>.selectionEvents(
  * ```
  */
 @CheckResult
-fun <T : Adapter> AdapterView<T>.selectionEvents(): InitialValueFlow<AdapterViewSelectionEvent> = channelFlow {
+fun <T : Adapter> AdapterView<T>.selectionEvents(): InitialValueFlow<AdapterViewSelectionEvent> = callbackFlow {
     onItemSelectedListener = listener(this, ::trySend)
     awaitClose { onItemSelectedListener = null }
 }.asInitialValueFlow(initialValue(adapterView = this))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewDismisses.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewDismisses.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -118,7 +118,7 @@ fun AutoCompleteTextView.dismisses(
  */
 @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 @CheckResult
-fun AutoCompleteTextView.dismisses(): Flow<Unit> = channelFlow {
+fun AutoCompleteTextView.dismisses(): Flow<Unit> = callbackFlow {
     setOnDismissListener(listener(this, ::trySend))
     awaitClose { setOnDismissListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewItemClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewItemClickEvents.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -115,7 +115,7 @@ fun AutoCompleteTextView.itemClickEvents(
  * ```
  */
 @CheckResult
-fun AutoCompleteTextView.itemClickEvents(): Flow<AdapterViewItemClickEvent> = channelFlow {
+fun AutoCompleteTextView.itemClickEvents(): Flow<AdapterViewItemClickEvent> = callbackFlow {
     onItemClickListener = listener(this, ::trySend)
     awaitClose { onItemClickListener = null }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CalendarViewDateChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CalendarViewDateChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -137,7 +137,7 @@ fun CalendarView.dateChangeEvents(
  * ```
  */
 @CheckResult
-fun CalendarView.dateChangeEvents(): InitialValueFlow<CalendarViewDateChangeEvent> = channelFlow {
+fun CalendarView.dateChangeEvents(): InitialValueFlow<CalendarViewDateChangeEvent> = callbackFlow {
     setOnDateChangeListener(listener(this, ::trySend))
     awaitClose { setOnDateChangeListener(null) }
 }.asInitialValueFlow(initialValue(calendar = this))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CompoundButtonCheckedChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CompoundButtonCheckedChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -127,7 +127,7 @@ fun CompoundButton.checkedChanges(
  * ```
  */
 @CheckResult
-fun CompoundButton.checkedChanges(): InitialValueFlow<Boolean> = channelFlow {
+fun CompoundButton.checkedChanges(): InitialValueFlow<Boolean> = callbackFlow {
     setOnCheckedChangeListener(listener(this, ::trySend))
     awaitClose { setOnCheckedChangeListener(null) }
 }.asInitialValueFlow(isChecked)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/DatePickerChangedEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/DatePickerChangedEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -141,7 +141,7 @@ fun DatePicker.dateChangeEvents(
  */
 @RequiresApi(Build.VERSION_CODES.O)
 @CheckResult
-fun DatePicker.dateChangeEvents(): InitialValueFlow<DateChangedEvent> = channelFlow {
+fun DatePicker.dateChangeEvents(): InitialValueFlow<DateChangedEvent> = callbackFlow {
     setOnDateChangedListener(listener(this, ::trySend))
     awaitClose { setOnDateChangedListener(null) }
 }.asInitialValueFlow(DateChangedEvent(view = this, year, month, dayOfMonth))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerScrollStateChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerScrollStateChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -112,7 +112,7 @@ fun NumberPicker.scrollStateChanges(
  * ```
  */
 @CheckResult
-fun NumberPicker.scrollStateChanges(): Flow<Int> = channelFlow {
+fun NumberPicker.scrollStateChanges(): Flow<Int> = callbackFlow {
     setOnScrollListener(listener(this, ::trySend))
     awaitClose { setOnScrollListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerValueChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerValueChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -136,7 +136,7 @@ fun NumberPicker.valueChangeEvents(
  * ```
  */
 @CheckResult
-fun NumberPicker.valueChangeEvents(): InitialValueFlow<NumberPickerValueChangeEvent> = channelFlow {
+fun NumberPicker.valueChangeEvents(): InitialValueFlow<NumberPickerValueChangeEvent> = callbackFlow {
     setOnValueChangedListener(listener(this, ::trySend))
     awaitClose { setOnValueChangedListener(null) }
 }.asInitialValueFlow(NumberPickerValueChangeEvent(picker = this, value, value))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuDismisses.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuDismisses.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -112,7 +112,7 @@ fun PopupMenu.dismisses(
  * ```
  */
 @CheckResult
-fun PopupMenu.dismisses(): Flow<Unit> = channelFlow {
+fun PopupMenu.dismisses(): Flow<Unit> = callbackFlow {
     setOnDismissListener(listener(this, ::trySend))
     awaitClose { setOnDismissListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuItemClicks.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -113,7 +113,7 @@ fun PopupMenu.itemClicks(
  * ```
  */
 @CheckResult
-fun PopupMenu.itemClicks(): Flow<MenuItem> = channelFlow {
+fun PopupMenu.itemClicks(): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RadioGroupCheckedChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RadioGroupCheckedChanges.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -130,7 +130,7 @@ fun RadioGroup.checkedChanges(
  * ```
  */
 @CheckResult
-fun RadioGroup.checkedChanges(): InitialValueFlow<Int> = channelFlow {
+fun RadioGroup.checkedChanges(): InitialValueFlow<Int> = callbackFlow {
     setOnCheckedChangeListener(listener(this, ::trySend))
     awaitClose { setOnCheckedChangeListener(null) }
 }.asInitialValueFlow(checkedRadioButtonId)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -134,7 +134,7 @@ fun RatingBar.ratingChangeEvents(
  * ```
  */
 @CheckResult
-fun RatingBar.ratingChangeEvents(): InitialValueFlow<RatingBarChangeEvent> = channelFlow {
+fun RatingBar.ratingChangeEvents(): InitialValueFlow<RatingBarChangeEvent> = callbackFlow {
     onRatingBarChangeListener = listener(this, ::trySend)
     awaitClose { onRatingBarChangeListener = null }
 }.asInitialValueFlow(initialValue(ratingBar = this))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -127,7 +127,7 @@ fun RatingBar.ratingChanges(
  * ```
  */
 @CheckResult
-fun RatingBar.ratingChanges(): InitialValueFlow<Float> = channelFlow {
+fun RatingBar.ratingChanges(): InitialValueFlow<Float> = callbackFlow {
     onRatingBarChangeListener = listener(this, ::trySend)
     awaitClose { onRatingBarChangeListener = null }
 }.asInitialValueFlow(rating)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -134,7 +134,7 @@ fun SearchView.queryTextChangeEvents(
  * ```
  */
 @CheckResult
-fun SearchView.queryTextChangeEvents(): InitialValueFlow<SearchViewQueryTextEvent> = channelFlow {
+fun SearchView.queryTextChangeEvents(): InitialValueFlow<SearchViewQueryTextEvent> = callbackFlow {
     setOnQueryTextListener(listener(this, this@queryTextChangeEvents, ::trySend))
     awaitClose { setOnQueryTextListener(null) }
 }.asInitialValueFlow(initialValue(searchView = this))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -128,7 +128,7 @@ fun SearchView.queryTextChanges(
  * ```
  */
 @CheckResult
-fun SearchView.queryTextChanges(): InitialValueFlow<CharSequence> = channelFlow {
+fun SearchView.queryTextChanges(): InitialValueFlow<CharSequence> = callbackFlow {
     setOnQueryTextListener(listener(this, ::trySend))
     awaitClose { setOnQueryTextListener(null) }
 }.asInitialValueFlow(query)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChangeEvents.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -173,7 +173,7 @@ fun SeekBar.changeEvents(
  * ```
  */
 @CheckResult
-fun SeekBar.changeEvents(): InitialValueFlow<SeekBarChangeEvent> = channelFlow {
+fun SeekBar.changeEvents(): InitialValueFlow<SeekBarChangeEvent> = callbackFlow {
     setOnSeekBarChangeListener(listener(this, ::trySend))
     awaitClose { setOnSeekBarChangeListener(null) }
 }.asInitialValueFlow(initialValue(seekBar = this))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChanges.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -66,7 +66,7 @@ private fun SeekBar.changes(
 }
 
 @CheckResult
-private fun SeekBar.changes(shouldBeFromUser: Boolean?): InitialValueFlow<Int> = channelFlow {
+private fun SeekBar.changes(shouldBeFromUser: Boolean?): InitialValueFlow<Int> = callbackFlow {
     setOnSeekBarChangeListener(listener(this, shouldBeFromUser, ::trySend))
     awaitClose { setOnSeekBarChangeListener(null) }
 }.asInitialValueFlow(progress)

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -125,7 +125,7 @@ fun TextView.afterTextChangeEvents(
  * ```
  */
 @CheckResult
-fun TextView.afterTextChangeEvents(): InitialValueFlow<TextViewAfterTextChangeEvent> = channelFlow {
+fun TextView.afterTextChangeEvents(): InitialValueFlow<TextViewAfterTextChangeEvent> = callbackFlow {
     val listener = listener(this, this@afterTextChangeEvents, ::trySend)
     addTextChangedListener(listener)
     awaitClose { removeTextChangedListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewBeforeTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewBeforeTextChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -126,7 +126,7 @@ fun TextView.beforeTextChangeEvents(
  * ```
  */
 @CheckResult
-fun TextView.beforeTextChangeEvents(): InitialValueFlow<TextViewBeforeTextChangeEvent> = channelFlow {
+fun TextView.beforeTextChangeEvents(): InitialValueFlow<TextViewBeforeTextChangeEvent> = callbackFlow {
     val listener = listener(this, this@beforeTextChangeEvents, ::trySend)
     addTextChangedListener(listener)
     awaitClose { removeTextChangedListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActionEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActionEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -135,7 +135,7 @@ fun TextView.editorActionEvents(
 @CheckResult
 fun TextView.editorActionEvents(
     handled: (TextViewEditorActionEvent) -> Boolean = AlwaysTrue,
-): Flow<TextViewEditorActionEvent> = channelFlow {
+): Flow<TextViewEditorActionEvent> = callbackFlow {
     setOnEditorActionListener(listener(this, handled, ::trySend))
     awaitClose { setOnEditorActionListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActions.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActions.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.AlwaysTrue
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
@@ -125,7 +125,7 @@ fun TextView.editorActions(
  * [TextView.OnEditorActionListener].
  */
 @CheckResult
-fun TextView.editorActions(handled: (Int) -> Boolean = AlwaysTrue): Flow<Int> = channelFlow {
+fun TextView.editorActions(handled: (Int) -> Boolean = AlwaysTrue): Flow<Int> = callbackFlow {
     setOnEditorActionListener(listener(this, handled, ::trySend))
     awaitClose { setOnEditorActionListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChangeEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -128,7 +128,7 @@ fun TextView.textChangeEvents(
  * ```
  */
 @CheckResult
-fun TextView.textChangeEvents(): InitialValueFlow<TextViewTextChangeEvent> = channelFlow {
+fun TextView.textChangeEvents(): InitialValueFlow<TextViewTextChangeEvent> = callbackFlow {
     val listener = listener(this, this@textChangeEvents, ::trySend)
     addTextChangedListener(listener)
     awaitClose { removeTextChangedListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChanges.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -120,7 +120,7 @@ fun TextView.textChanges(
  * ```
  */
 @CheckResult
-fun TextView.textChanges(): InitialValueFlow<CharSequence> = channelFlow {
+fun TextView.textChanges(): InitialValueFlow<CharSequence> = callbackFlow {
     val listener = listener(this, ::trySend)
     addTextChangedListener(listener)
     awaitClose { removeTextChangedListener(listener) }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TimePickerChangedEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TimePickerChangedEvents.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.InitialValueFlow
 import ru.ldralighieri.corbind.internal.asInitialValueFlow
@@ -140,7 +140,7 @@ fun TimePicker.timeChangeEvents(
  */
 @RequiresApi(Build.VERSION_CODES.M)
 @CheckResult
-fun TimePicker.timeChangeEvents(): InitialValueFlow<TimeChangedEvent> = channelFlow {
+fun TimePicker.timeChangeEvents(): InitialValueFlow<TimeChangedEvent> = callbackFlow {
     setOnTimeChangedListener(listener(this, ::trySend))
     awaitClose { setOnTimeChangedListener(null) }
 }.asInitialValueFlow(TimeChangedEvent(view = this, hour, minute))

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarItemClicks.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun Toolbar.itemClicks(
  */
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 @CheckResult
-fun Toolbar.itemClicks(): Flow<MenuItem> = channelFlow {
+fun Toolbar.itemClicks(): Flow<MenuItem> = callbackFlow {
     setOnMenuItemClickListener(listener(this, ::trySend))
     awaitClose { setOnMenuItemClickListener(null) }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarNavigationClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarNavigationClicks.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
@@ -119,7 +119,7 @@ fun Toolbar.navigationClicks(
  */
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 @CheckResult
-fun Toolbar.navigationClicks(): Flow<Unit> = channelFlow {
+fun Toolbar.navigationClicks(): Flow<Unit> = callbackFlow {
     setNavigationOnClickListener(listener(this, ::trySend))
     awaitClose { setNavigationOnClickListener(null) }
 }


### PR DESCRIPTION
- Replace channelFlow with callbackFlow across Android callback bindings.