### PR TITLE
Modernize lifecycle and legacy API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please consider giving this repository a star ⭐ if you like the project.
 | [corbind-recyclerview]       | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-recyclerview.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-recyclerview)             |
 | [corbind-slidingpanelayout]  | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-slidingpanelayout.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-slidingpanelayout)   |
 | [corbind-swiperefreshlayout] | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-swiperefreshlayout.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-swiperefreshlayout) |
-| [corbind-viewpager]          | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-viewpager.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-viewpager)                   |
+| [corbind-viewpager] (legacy) | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-viewpager.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-viewpager)                   |
 | [corbind-viewpager2]         | [![Maven Central](https://img.shields.io/maven-central/v/ru.ldralighieri.corbind/corbind-viewpager2.svg)](https://mvnrepository.com/artifact/ru.ldralighieri.corbind/corbind-viewpager2)                 |
 
 
@@ -74,7 +74,7 @@ dependencies {
     implementation("ru.ldralighieri.corbind:corbind-recyclerview")
     implementation("ru.ldralighieri.corbind:corbind-slidingpanelayout")
     implementation("ru.ldralighieri.corbind:corbind-swiperefreshlayout")
-    implementation("ru.ldralighieri.corbind:corbind-viewpager")
+    implementation("ru.ldralighieri.corbind:corbind-viewpager") // legacy
     implementation("ru.ldralighieri.corbind:corbind-viewpager2")
 }
 ```
@@ -103,20 +103,20 @@ dependencies {
 ## List of extensions
 
 You can find a list of extensions in the description of each module:  
-* [corbind]  
-* [corbind-activity]  
-* [corbind-appcompat]  
-* [corbind-core]  
-* [corbind-drawerlayout]  
-* [corbind-fragment]  
-* [corbind-leanback]  
-* [corbind-lifecycle]  
-* [corbind-material]  
-* [corbind-navigation]  
-* [corbind-recyclerview]  
-* [corbind-slidingpanelayout]  
-* [corbind-swiperefreshlayout]  
-* [corbind-viewpager]  
+* [corbind]
+* [corbind-activity]
+* [corbind-appcompat]
+* [corbind-core]
+* [corbind-drawerlayout]
+* [corbind-fragment]
+* [corbind-leanback]
+* [corbind-lifecycle]
+* [corbind-material]
+* [corbind-navigation]
+* [corbind-recyclerview]
+* [corbind-slidingpanelayout]
+* [corbind-swiperefreshlayout]
+* [corbind-viewpager] (legacy)
 * [corbind-viewpager2]
 
 
@@ -131,13 +131,13 @@ findViewById<EditText>(R.id.etName)
     .launchIn(lifecycleScope) // lifecycle-runtime-ktx
 ```
 
-If you prefer hot [ReceiveChannel][channel] and you need to get a ViewPager page selection events, then the use case will transform in something like this:
+If you prefer hot [ReceiveChannel][channel] and you need to get ViewPager2 page selection events, then the use case will transform in something like this:
 ```kotlin
 launch {
-    findViewById<ViewPager>(R.id.vpSlides)
+    findViewById<ViewPager2>(R.id.vpSlides)
         .pageSelections(scope) // ReceiveChannel<Int>
         .consumeEach {
-            /* handle ViewPager events */
+            /* handle ViewPager2 events */
         }
 }
 ```
@@ -208,6 +208,7 @@ limitations under the License.
 
 [kotlin-coroutine-binding]: https://medium.com/@ldralighieri/kotlin-coroutine-binding-with-flow-support-68499492a89c
 [release-1.7.0]: https://medium.com/@ldralighieri/whats-up-corbind-release-1-7-0-it-s-been-a-long-road-eadf84db19c1
+[viewpager2-migration]: https://developer.android.com/develop/ui/views/animations/vp2-migration
 
 [corbind-bom]: https://github.com/LDRAlighieri/Corbind/tree/master/corbind-bom
 [corbind]: https://github.com/LDRAlighieri/Corbind/tree/master/corbind

--- a/corbind-fragment/README.md
+++ b/corbind-fragment/README.md
@@ -18,14 +18,13 @@ dependencies {
 ## Simple examples
 
 ```kotlin
-lifecycleScope.launchWhenStarted {
-    parentFragmentManager.resultEvents(
-        requestKey = FRAGMENT_REQUEST_KEY,
-        lifecycleOwner = this@CurrentFragment
-    ) // Flow<FragmentResultEvent>
-        .onEach { event -> /* handle result event */ }
-        .launchIn(this@launchWhenStarted) // lifecycle-runtime-ktx
-}
+parentFragmentManager.resultEvents(
+    requestKey = FRAGMENT_REQUEST_KEY,
+    lifecycleOwner = viewLifecycleOwner,
+) // Flow<FragmentResultEvent>
+    .flowWithLifecycle(viewLifecycleOwner.lifecycle)
+    .onEach { event -> /* handle result event */ }
+    .launchIn(viewLifecycleOwner.lifecycleScope) // lifecycle-runtime-ktx
 ```
 
 More examples in source code

--- a/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
+++ b/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
@@ -130,14 +130,13 @@ fun FragmentManager.resultEvents(
  *
  * Example:
  * ```
- * lifecycleScope.launchWhenStarted {
- *      parentFragmentManager.resultEvents(
- *          requestKey = FRAGMENT_REQUEST_KEY,
- *          lifecycleOwner = this@CurrentFragment
- *      )
- *          .onEach { event -> /* handle result event */ }
- *          .launchIn(this@launchWhenStarted) // lifecycle-runtime-ktx
- * }
+ * parentFragmentManager.resultEvents(
+ *     requestKey = FRAGMENT_REQUEST_KEY,
+ *     lifecycleOwner = viewLifecycleOwner,
+ * )
+ *     .flowWithLifecycle(viewLifecycleOwner.lifecycle)
+ *     .onEach { event -> /* handle result event */ }
+ *     .launchIn(viewLifecycleOwner.lifecycleScope) // lifecycle-runtime-ktx
  * ```
  *
  * @param requestKey Used to identify the result

--- a/corbind-viewpager/README.md
+++ b/corbind-viewpager/README.md
@@ -1,6 +1,11 @@
 ﻿
 # corbind-viewpager
 
+> **Legacy module:** `corbind-viewpager` is maintained for compatibility with
+> `androidx.viewpager.widget.ViewPager`. Use [`corbind-viewpager2`][corbind-viewpager2] for new code.
+> No new APIs are planned without a compelling compatibility reason. See the official
+> [ViewPager2 migration guide][viewpager2-migration].
+
 To add androidx viewpager bindings, import `corbind-viewpager` module:
 
 ```kotlin
@@ -28,6 +33,8 @@ vpSlides.pageSelections() // Flow<Int>
 
 More examples in source code
 
+[corbind-viewpager2]: https://github.com/LDRAlighieri/Corbind/tree/master/corbind-viewpager2
+[viewpager2-migration]: https://developer.android.com/develop/ui/views/animations/vp2-migration
 [ViewPager_pageScrollEvents]: https://github.com/LDRAlighieri/Corbind/blob/master/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollEvents.kt
 [ViewPager_pageScrollStateChanges]: https://github.com/LDRAlighieri/Corbind/blob/master/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollStateChanges.kt
 [ViewPager_pageSelections]: https://github.com/LDRAlighieri/Corbind/blob/master/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageSelections.kt

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
@@ -48,10 +48,10 @@ fun View.globalLayouts(
     }
 
     val listener = listener(scope, events::trySend)
-    viewTreeObserver.addOnGlobalLayoutListener(listener)
+    val observer = viewTreeObserver
+    observer.addOnGlobalLayoutListener(listener)
     events.invokeOnClose {
-        @Suppress("DEPRECATION") // Correct when minSdk 16
-        viewTreeObserver.removeGlobalOnLayoutListener(listener)
+        removeOnGlobalLayoutListener(observer, listener)
     }
 }
 
@@ -89,10 +89,10 @@ fun View.globalLayouts(
     capacity: Int = Channel.RENDEZVOUS,
 ): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
     val listener = listener(scope, ::trySend)
-    viewTreeObserver.addOnGlobalLayoutListener(listener)
+    val observer = viewTreeObserver
+    observer.addOnGlobalLayoutListener(listener)
     invokeOnClose {
-        @Suppress("DEPRECATION") // Correct when minSdk 16
-        viewTreeObserver.removeGlobalOnLayoutListener(listener)
+        removeOnGlobalLayoutListener(observer, listener)
     }
 }
 
@@ -111,10 +111,10 @@ fun View.globalLayouts(
 @CheckResult
 fun View.globalLayouts(): Flow<Unit> = callbackFlow {
     val listener = listener(this, ::trySend)
-    viewTreeObserver.addOnGlobalLayoutListener(listener)
+    val observer = viewTreeObserver
+    observer.addOnGlobalLayoutListener(listener)
     awaitClose {
-        @Suppress("DEPRECATION") // Correct when minSdk 16
-        viewTreeObserver.removeGlobalOnLayoutListener(listener)
+        removeOnGlobalLayoutListener(observer, listener)
     }
 }
 
@@ -124,4 +124,12 @@ private fun listener(
     emitter: (Unit) -> Unit,
 ) = ViewTreeObserver.OnGlobalLayoutListener {
     if (scope.isActive) emitter(Unit)
+}
+
+private fun View.removeOnGlobalLayoutListener(
+    registeredObserver: ViewTreeObserver,
+    listener: ViewTreeObserver.OnGlobalLayoutListener,
+) {
+    val observer = registeredObserver.takeIf { it.isAlive } ?: viewTreeObserver
+    if (observer.isAlive) observer.removeOnGlobalLayoutListener(listener)
 }


### PR DESCRIPTION
- Replace deprecated Fragment lifecycle examples with `flowWithLifecycle`.
- Mark `corbind-viewpager` as maintenance-only legacy and recommend ViewPager2.
- Remove deprecated `ViewTreeObserver` cleanup and handle observer lifecycle safely.