### PR TITLE
Fix backProgressed commit delegation

### DIFF
--- a/corbind-activity/build.gradle.kts
+++ b/corbind-activity/build.gradle.kts
@@ -28,4 +28,7 @@ android {
 dependencies {
     api(projects.corbind)
     api(libs.androidx.activity)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
@@ -16,6 +16,8 @@
 
 package ru.ldralighieri.corbind.activity
 
+import android.os.Handler
+import android.os.Looper
 import androidx.activity.BackEventCompat
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
@@ -35,6 +37,9 @@ import ru.ldralighieri.corbind.internal.corbindReceiveChannel
 
 /**
  * Perform an action on [OnBackPressedDispatcher.dispatchOnBackProgressed] call.
+ *
+ * A committed back is delegated to the next enabled callback or to the dispatcher's fallback. Use
+ * [backEvents] when the complete predictive back gesture lifecycle is needed.
  *
  * @param scope Root coroutine scope
  * @param lifecycleOwner The LifecycleOwner which controls when the callback should be invoked
@@ -60,6 +65,9 @@ fun OnBackPressedDispatcher.backProgressed(
  * Perform an action on [OnBackPressedDispatcher.dispatchOnBackProgressed] call, inside new
  * [CoroutineScope].
  *
+ * A committed back is delegated to the next enabled callback or to the dispatcher's fallback. Use
+ * [backEvents] when the complete predictive back gesture lifecycle is needed.
+ *
  * @param lifecycleOwner The LifecycleOwner which controls when the callback should be invoked
  * @param capacity Capacity of the channel's buffer (no buffer by default)
  * @param action An action to perform
@@ -75,6 +83,9 @@ suspend fun OnBackPressedDispatcher.backProgressed(
 /**
  * Create a channel which emits back progress on [OnBackPressedDispatcher.dispatchOnBackProgressed]
  * call.
+ *
+ * A committed back is delegated to the next enabled callback or to the dispatcher's fallback. Use
+ * [backEvents] when the complete predictive back gesture lifecycle is needed.
  *
  * Example:
  *
@@ -103,6 +114,9 @@ fun OnBackPressedDispatcher.backProgressed(
  * Create a flow which emits back progress on [OnBackPressedDispatcher.dispatchOnBackProgressed]
  * call.
  *
+ * A committed back is delegated to the next enabled callback or to the dispatcher's fallback. Use
+ * [backEvents] when the complete predictive back gesture lifecycle is needed.
+ *
  * Example:
  *
  * ```
@@ -121,14 +135,33 @@ fun OnBackPressedDispatcher.backProgressed(lifecycleOwner: LifecycleOwner): Flow
 }
 
 @CheckResult
-private fun callback(
+private fun OnBackPressedDispatcher.callback(
     scope: CoroutineScope,
     emitter: (Float) -> Unit,
-) = object : OnBackPressedCallback(true) {
+): OnBackPressedCallback {
+    val dispatcher = this
 
-    override fun handleOnBackProgressed(backEvent: BackEventCompat) {
-        if (scope.isActive) emitter(backEvent.progress)
+    return object : OnBackPressedCallback(true) {
+        private val mainHandler = Handler(Looper.getMainLooper())
+
+        override fun handleOnBackProgressed(backEvent: BackEventCompat) {
+            if (scope.isActive) emitter(backEvent.progress)
+        }
+
+        override fun handleOnBackPressed() {
+            isEnabled = false
+            // AndroidX finishes the predictive gesture after this callback returns. Redispatch on
+            // the next main-loop turn so it can select the next callback or the fallback.
+            val posted = mainHandler.post {
+                try {
+                    dispatcher.onBackPressed()
+                } finally {
+                    isEnabled = true
+                }
+            }
+            if (!posted) {
+                isEnabled = true
+            }
+        }
     }
-
-    override fun handleOnBackPressed() = Unit
 }

--- a/corbind-activity/src/test/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressedTest.kt
+++ b/corbind-activity/src/test/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressedTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Vladimir Raupov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.ldralighieri.corbind.activity
+
+import android.os.Build
+import android.os.Looper
+import androidx.activity.BackEventCompat
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+@LooperMode(LooperMode.Mode.PAUSED)
+class OnBackPressedDispatcherBackProgressedTest {
+
+    private lateinit var dispatcher: OnBackPressedDispatcher
+    private lateinit var lifecycleOwner: TestLifecycleOwner
+    private lateinit var scope: CoroutineScope
+    private var binding: ReceiveChannel<Float>? = null
+
+    @Before
+    fun setUp() {
+        dispatcher = OnBackPressedDispatcher()
+        lifecycleOwner = TestLifecycleOwner()
+        lifecycleOwner.registry.currentState = Lifecycle.State.STARTED
+        scope = CoroutineScope(SupervisorJob())
+    }
+
+    @After
+    fun tearDown() {
+        binding?.cancel()
+        scope.cancel()
+    }
+
+    @Test
+    fun `committed predictive back is delegated to the next callback`() {
+        // given
+        var backPresses = 0
+        dispatcher.addCallback(
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    backPresses++
+                }
+            },
+        )
+        bindBackProgressed()
+
+        // when
+        dispatcher.dispatchOnBackStarted(backEvent(progress = 0f))
+        dispatcher.dispatchOnBackProgressed(backEvent(progress = 0.5f))
+        val emittedProgress = binding?.tryReceive()?.getOrThrow()
+        dispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then
+        assertEquals(0.5f, emittedProgress)
+        assertEquals(1, backPresses)
+    }
+
+    @Test
+    fun `committed predictive back is delegated to the dispatcher fallback`() {
+        // given
+        var fallbackCalls = 0
+        dispatcher = OnBackPressedDispatcher { fallbackCalls++ }
+        bindBackProgressed()
+
+        // when
+        dispatcher.dispatchOnBackStarted(backEvent(progress = 0f))
+        dispatcher.dispatchOnBackProgressed(backEvent(progress = 0.5f))
+        dispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then
+        assertEquals(1, fallbackCalls)
+    }
+
+    @Test
+    fun `cancelled predictive back is not delegated`() {
+        // given
+        var backPresses = 0
+        dispatcher.addCallback(
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    backPresses++
+                }
+            },
+        )
+        bindBackProgressed()
+
+        // when
+        dispatcher.dispatchOnBackStarted(backEvent(progress = 0f))
+        dispatcher.dispatchOnBackProgressed(backEvent(progress = 0.5f))
+        dispatcher.dispatchOnBackCancelled()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then
+        assertEquals(0, backPresses)
+
+        // when
+        dispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then
+        assertEquals(1, backPresses)
+    }
+
+    @Test
+    fun `stopped lifecycle does not intercept committed back`() {
+        // given
+        var backPresses = 0
+        dispatcher.addCallback(
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    backPresses++
+                }
+            },
+        )
+        bindBackProgressed()
+        lifecycleOwner.registry.currentState = Lifecycle.State.CREATED
+
+        // when
+        dispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then
+        assertEquals(1, backPresses)
+    }
+
+    private fun bindBackProgressed() {
+        binding = dispatcher.backProgressed(
+            scope = scope,
+            lifecycleOwner = lifecycleOwner,
+            capacity = Channel.UNLIMITED,
+        )
+    }
+
+    private fun backEvent(progress: Float): BackEventCompat = BackEventCompat(
+        touchX = 0f,
+        touchY = 0f,
+        progress = progress,
+        swipeEdge = BackEventCompat.EDGE_LEFT,
+    )
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        val registry = LifecycleRegistry(this)
+
+        override val lifecycle: Lifecycle = registry
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,10 @@ material = "1.14.0"
 # Lint
 ktlint = "1.8.0"
 
+# Test
+junit = "4.13.2"
+robolectric = "4.16.1"
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -73,6 +77,10 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 
 # Google
 material = { module = "com.google.android.material:material", version.ref = "material" }
+
+# Test
+junit = { module = "junit:junit", version.ref = "junit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 
 # build-logic


### PR DESCRIPTION
- Delegate committed back events to the next enabled callback or dispatcher fallback.
- Document `backEvents()` as the full predictive-back lifecycle API.
- Add Robolectric regression coverage for commit, cancellation, fallback, and lifecycle behavior.