### PR TITLE
Restore Android API validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Check spotless
         run: ./gradlew spotlessCheck --no-configuration-cache
 
+      - name: Check binary compatibility
+        run: ./gradlew apiCheck
+
       - name: Build the sample app to verify it works
         run: ./gradlew sample:assemble

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     compileOnly(libs.spotless.gradlePlugin)
     compileOnly(libs.maven.publish.gradlePlugin)
     implementation(libs.dokka.gradlePlugin)
+    implementation(libs.binary.compatibility.validator.gradlePlugin)
 }
 
 tasks {

--- a/build-logic/convention/src/main/kotlin/ApiDumpTask.kt
+++ b/build-logic/convention/src/main/kotlin/ApiDumpTask.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Vladimir Raupov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Based on the Android BCV Bridge implementation:
+ * https://github.com/tjokinen/android-bcv-bridge/blob/main/src/main/kotlin/io/github/tjokinen/androidbcvbridge/ApiDumpTask.kt
+ */
+@DisableCachingByDefault(because = "Trivial copy of the generated dump over the committed file")
+abstract class ApiDumpTask : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val generatedApiFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val committedApiFile: RegularFileProperty
+
+    @TaskAction
+    fun dump() {
+        val generated = generatedApiFile.get().asFile
+        val committed = committedApiFile.get().asFile
+        committed.parentFile.mkdirs()
+        generated.copyTo(committed, overwrite = true)
+    }
+}

--- a/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/LibraryConventionPlugin.kt
@@ -15,9 +15,13 @@
  */
 
 import com.android.build.api.dsl.LibraryExtension
+import kotlinx.validation.KotlinApiBuildTask
+import kotlinx.validation.KotlinApiCompareTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
 import ru.ldralighieri.corbind.configureKotlinAndroid
 
 @Suppress("unused")
@@ -36,6 +40,49 @@ class LibraryConventionPlugin : Plugin<Project> {
                         proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
                     }
                 }
+            }
+
+            configureApiValidation()
+        }
+    }
+
+    private fun Project.configureApiValidation() {
+        // BCV does not discover Android libraries that use AGP 9 built-in Kotlin.
+        // Register its JVM API tasks against the release compilation until upstream support lands:
+        // https://github.com/Kotlin/binary-compatibility-validator/issues/312
+        afterEvaluate {
+            val kotlinClasses = tasks.named("compileReleaseKotlin").map { it.outputs.files }
+            val javaClasses = tasks.named("compileReleaseJavaWithJavac").map { it.outputs.files }
+            val generatedApi = layout.buildDirectory.file("api/$name.api")
+            val committedApi = layout.projectDirectory.file("api/$name.api")
+
+            val apiBuild = tasks.register<KotlinApiBuildTask>("apiBuild") {
+                description = "Builds the public API dump for $name."
+                inputClassesDirs.from(kotlinClasses, javaClasses)
+                outputApiFile.set(generatedApi)
+                runtimeClasspath.from(configurations.named("bcv-rt-jvm-cp-resolver"))
+            }
+
+            val apiCheck = tasks.register<KotlinApiCompareTask>("apiCheck") {
+                group = "verification"
+                description = "Checks the public API of $name against the committed dump."
+                projectApiFile.set(committedApi)
+                generatedApiFile.set(apiBuild.flatMap { it.outputApiFile })
+            }
+
+            val apiDump = tasks.register<ApiDumpTask>("apiDump") {
+                group = "verification"
+                description = "Updates the committed public API dump for $name."
+                generatedApiFile.set(apiBuild.flatMap { it.outputApiFile })
+                committedApiFile.set(committedApi)
+            }
+
+            apiCheck.configure {
+                mustRunAfter(apiDump)
+            }
+
+            tasks.named("check") {
+                dependsOn(apiCheck)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,7 @@ plugins {
 // Binary compatibility validator
 apiValidation {
     ignoredProjects.add("sample")
-    ignoredPackages.add("ru/ldralighieri/corbind/internal")
-    ignoredPackages.add("corbind-bom")
+    nonPublicMarkers.add("androidx.annotation.RestrictTo")
 }
 
 // Dependency updates

--- a/corbind/api/corbind.api
+++ b/corbind/api/corbind.api
@@ -35,6 +35,13 @@ public final class ru/ldralighieri/corbind/content/ContextReceivesBroadcastKt {
 	public static synthetic fun receivesBroadcast$default (Landroid/content/Context;Lkotlinx/coroutines/CoroutineScope;Landroid/content/IntentFilter;ILkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 
+public final class ru/ldralighieri/corbind/internal/InitialValueFlow : kotlinx/coroutines/flow/Flow {
+	public fun <init> (Lkotlinx/coroutines/flow/Flow;)V
+	public final fun asStateFlow (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun dropInitialValue ()Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class ru/ldralighieri/corbind/view/MenuItemActionViewCollapseEvent : ru/ldralighieri/corbind/view/MenuItemActionViewEvent {
 	public fun <init> (Landroid/view/MenuItem;)V
 	public final fun component1 ()Landroid/view/MenuItem;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,3 +89,4 @@ kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 maven-publish-gradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+binary-compatibility-validator-gradlePlugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "bcv" }


### PR DESCRIPTION
- Restore BCV apiCheck and apiDump tasks for Android libraries using AGP 9 built-in Kotlin.
- Run API validation in the pull request workflow and include InitialValueFlow in the committed API baseline.
- Track the upstream task-registration gap in https://github.com/Kotlin/binary-compatibility-validator/issues/312.