### PR TITLE
Tie receive channels to CoroutineScope lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ launch {
 }
 ```
 
+The `Job` in the passed `CoroutineScope` owns a hot channel binding. When that job completes, either
+normally or through cancellation, the channel is cancelled and its Android callback is removed.
+Cancelling the returned channel also removes the callback without cancelling the scope. If the scope
+is already cancelled, the callback is not registered. Registration and removal are performed on the
+Android main thread.
+
 And if you just need to perform an action on button click, the easiest way will be:
 ```kotlin
 launch {

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackPresses.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackPresses.kt
@@ -90,10 +90,10 @@ fun OnBackPressedDispatcher.backPresses(
     scope: CoroutineScope,
     lifecycleOwner: LifecycleOwner,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     addCallback(lifecycleOwner, callback)
-    invokeOnClose { callback.remove() }
+    awaitClose { callback.remove() }
 }
 
 /**

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherBackProgressed.kt
@@ -104,10 +104,10 @@ fun OnBackPressedDispatcher.backProgressed(
     scope: CoroutineScope,
     lifecycleOwner: LifecycleOwner,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     addCallback(lifecycleOwner, callback)
-    invokeOnClose { callback.remove() }
+    awaitClose { callback.remove() }
 }
 
 /**

--- a/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherOnBackEvents.kt
+++ b/corbind-activity/src/main/kotlin/ru/ldralighieri/corbind/activity/OnBackPressedDispatcherOnBackEvents.kt
@@ -111,10 +111,10 @@ fun OnBackPressedDispatcher.backEvents(
     scope: CoroutineScope,
     lifecycleOwner: LifecycleOwner,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<OnBackEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<OnBackEvent> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     addCallback(lifecycleOwner, callback)
-    invokeOnClose { callback.remove() }
+    awaitClose { callback.remove() }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ActionMenuViewItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ActionMenuViewItemClicks.kt
@@ -92,9 +92,9 @@ suspend fun ActionMenuView.itemClicks(
 fun ActionMenuView.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuDismisses.kt
@@ -91,9 +91,9 @@ suspend fun PopupMenu.dismisses(
 fun PopupMenu.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnDismissListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDismissListener(null) }
+    awaitClose { setOnDismissListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/PopupMenuItemClicks.kt
@@ -92,9 +92,9 @@ suspend fun PopupMenu.itemClicks(
 fun PopupMenu.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChangeEvents.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChangeEvents.kt
@@ -102,10 +102,10 @@ suspend fun SearchView.queryTextChangeEvents(
 fun SearchView.queryTextChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SearchViewQueryTextEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SearchViewQueryTextEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(SearchViewQueryTextEvent(this@queryTextChangeEvents, query, false))
     setOnQueryTextListener(listener(scope, this@queryTextChangeEvents, ::trySend))
-    invokeOnClose { setOnQueryTextListener(null) }
+    awaitClose { setOnQueryTextListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChanges.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/SearchViewQueryTextChanges.kt
@@ -96,10 +96,10 @@ suspend fun SearchView.queryTextChanges(
 fun SearchView.queryTextChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<CharSequence> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<CharSequence> = corbindReceiveChannel(scope, capacity) {
     trySend(query)
     setOnQueryTextListener(listener(scope, ::trySend))
-    invokeOnClose { setOnQueryTextListener(null) }
+    awaitClose { setOnQueryTextListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarItemClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarItemClicks.kt
@@ -92,9 +92,9 @@ suspend fun Toolbar.itemClicks(
 fun Toolbar.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarNavigationClicks.kt
+++ b/corbind-appcompat/src/main/kotlin/ru/ldralighieri/corbind/appcompat/ToolbarNavigationClicks.kt
@@ -92,9 +92,9 @@ suspend fun Toolbar.navigationClicks(
 fun Toolbar.navigationClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setNavigationOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setNavigationOnClickListener(null) }
+    awaitClose { setNavigationOnClickListener(null) }
 }
 
 /**

--- a/corbind-core/src/main/kotlin/ru/ldralighieri/corbind/core/NestedScrollViewScrollChangeEvents.kt
+++ b/corbind-core/src/main/kotlin/ru/ldralighieri/corbind/core/NestedScrollViewScrollChangeEvents.kt
@@ -94,9 +94,9 @@ suspend fun NestedScrollView.scrollChangeEvents(
 fun NestedScrollView.scrollChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewScrollChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewScrollChangeEvent> = corbindReceiveChannel(scope, capacity) {
     setOnScrollChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnScrollChangeListener(null as NestedScrollView.OnScrollChangeListener?) }
+    awaitClose { setOnScrollChangeListener(null as NestedScrollView.OnScrollChangeListener?) }
 }
 
 /**

--- a/corbind-drawerlayout/src/main/kotlin/ru/ldralighieri/corbind/drawerlayout/DrawerLayoutDrawerOpen.kt
+++ b/corbind-drawerlayout/src/main/kotlin/ru/ldralighieri/corbind/drawerlayout/DrawerLayoutDrawerOpen.kt
@@ -94,11 +94,11 @@ fun DrawerLayout.drawerOpens(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     gravity: Int,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     trySend(isDrawerOpen(gravity))
     val listener = listener(scope, gravity, ::trySend)
     addDrawerListener(listener)
-    invokeOnClose { removeDrawerListener(listener) }
+    awaitClose { removeDrawerListener(listener) }
 }
 
 /**

--- a/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
+++ b/corbind-fragment/src/main/kotlin/ru/ldralighieri/corbind/fragment/FragmentManagerResultEvents.kt
@@ -115,10 +115,10 @@ fun FragmentManager.resultEvents(
     requestKey: String,
     lifecycleOwner: LifecycleOwner,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<FragmentResultEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<FragmentResultEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     setFragmentResultListener(requestKey, lifecycleOwner, listener)
-    invokeOnClose { clearFragmentResultListener(requestKey) }
+    awaitClose { clearFragmentResultListener(requestKey) }
 }
 
 /**

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChangeEvents.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChangeEvents.kt
@@ -128,9 +128,9 @@ suspend fun SearchBar.searchQueryChangeEvents(
 fun SearchBar.searchQueryChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SearchBarSearchQueryEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SearchBarSearchQueryEvent> = corbindReceiveChannel(scope, capacity) {
     setSearchBarListener(listener(scope, this@searchQueryChangeEvents, ::trySend))
-    invokeOnClose { setSearchBarListener(null) }
+    awaitClose { setSearchBarListener(null) }
 }
 
 /**

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChanges.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchBarSearchQueryChanges.kt
@@ -92,9 +92,9 @@ suspend fun SearchBar.searchQueryChanges(
 fun SearchBar.searchQueryChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<String> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<String> = corbindReceiveChannel(scope, capacity) {
     setSearchBarListener(listener(scope, ::trySend))
-    invokeOnClose { setSearchBarListener(null) }
+    awaitClose { setSearchBarListener(null) }
 }
 
 /**

--- a/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchEditTextKeyboardDismisses.kt
+++ b/corbind-leanback/src/main/kotlin/ru/ldralighieri/corbind/leanback/SearchEditTextKeyboardDismisses.kt
@@ -92,9 +92,9 @@ suspend fun SearchEditText.keyboardDismisses(
 fun SearchEditText.keyboardDismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnKeyboardDismissListener(listener(scope, ::trySend))
-    invokeOnClose { setOnKeyboardDismissListener(null) }
+    awaitClose { setOnKeyboardDismissListener(null) }
 }
 
 /**

--- a/corbind-lifecycle/src/main/kotlin/ru/ldralighieri/corbind/lifecycle/LifecycleEvents.kt
+++ b/corbind-lifecycle/src/main/kotlin/ru/ldralighieri/corbind/lifecycle/LifecycleEvents.kt
@@ -83,10 +83,10 @@ suspend fun Lifecycle.events(
 fun Lifecycle.events(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Lifecycle.Event> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Lifecycle.Event> = corbindReceiveChannel(scope, capacity) {
     val observer = observer(scope, ::trySend)
     addObserver(observer)
-    invokeOnClose { removeObserver(observer) }
+    awaitClose { removeObserver(observer) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/AppBarLayoutOffsetChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/AppBarLayoutOffsetChanges.kt
@@ -83,10 +83,10 @@ suspend fun AppBarLayout.offsetChanges(
 fun AppBarLayout.offsetChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnOffsetChangedListener(listener)
-    invokeOnClose { removeOnOffsetChangedListener(listener) }
+    awaitClose { removeOnOffsetChangedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorSlides.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorSlides.kt
@@ -86,11 +86,11 @@ suspend fun View.slides(
 fun View.slides(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBottomSheetBehavior()
     val callback = callback(scope, ::trySend)
     behavior.addBottomSheetCallback(callback)
-    invokeOnClose { behavior.removeBottomSheetCallback(callback) }
+    awaitClose { behavior.removeBottomSheetCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/BottomSheetBehaviorStateChanges.kt
@@ -91,12 +91,12 @@ suspend fun View.stateChanges(
 fun View.stateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBottomSheetBehavior()
     trySend(behavior.state)
     val callback = callback(scope, ::trySend)
     behavior.addBottomSheetCallback(callback)
-    invokeOnClose { behavior.removeBottomSheetCallback(callback) }
+    awaitClose { behavior.removeBottomSheetCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipCloseIconClicks.kt
@@ -92,9 +92,9 @@ suspend fun Chip.closeIconClicks(
 fun Chip.closeIconClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnCloseIconClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnCloseIconClickListener(null) }
+    awaitClose { setOnCloseIconClickListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipGroupCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/ChipGroupCheckedChanges.kt
@@ -96,10 +96,10 @@ suspend fun ChipGroup.checkedChanges(
 fun ChipGroup.checkedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<List<Int>> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<List<Int>> = corbindReceiveChannel(scope, capacity) {
     trySend(checkedChipIds)
     setOnCheckedStateChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnCheckedStateChangeListener(null) }
+    awaitClose { setOnCheckedStateChangeListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideBottomViewOnScrollBehaviorScrollStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideBottomViewOnScrollBehaviorScrollStateChanges.kt
@@ -105,11 +105,11 @@ suspend fun View.bottomViewScrollStateChanges(
 fun View.bottomViewScrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBehavior()
     val listener = listener(scope, ::trySend)
     behavior.addOnScrollStateChangedListener(listener)
-    invokeOnClose { behavior.removeOnScrollStateChangedListener(listener) }
+    awaitClose { behavior.removeOnScrollStateChangedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideViewOnScrollBehaviorScrollStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/HideViewOnScrollBehaviorScrollStateChanges.kt
@@ -91,11 +91,11 @@ suspend fun View.hideOnScrollStateChanges(
 fun View.hideOnScrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBehavior()
     val listener = listener(scope, ::trySend)
     behavior.addOnScrollStateChangedListener(listener)
-    invokeOnClose { behavior.removeOnScrollStateChangedListener(listener) }
+    awaitClose { behavior.removeOnScrollStateChangedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaskableFrameLayoutMaskChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaskableFrameLayoutMaskChanges.kt
@@ -91,9 +91,9 @@ suspend fun MaskableFrameLayout.maskChanges(
 fun MaskableFrameLayout.maskChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RectF> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RectF> = corbindReceiveChannel(scope, capacity) {
     setOnMaskChangedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMaskChangedListener(null) }
+    awaitClose { setOnMaskChangedListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonCheckedChanges.kt
@@ -94,12 +94,12 @@ suspend fun MaterialButton.checkedChanges(
 fun MaterialButton.checkedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     checkCheckableState(this@checkedChanges)
     trySend(isChecked)
     val listener = listener(scope, ::trySend)
     addOnCheckedChangeListener(listener)
-    invokeOnClose { removeOnCheckedChangeListener(listener) }
+    awaitClose { removeOnCheckedChangeListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChangeEvents.kt
@@ -99,11 +99,11 @@ suspend fun MaterialButtonToggleGroup.buttonCheckedChangeEvents(
 fun MaterialButtonToggleGroup.buttonCheckedChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MaterialButtonCheckedChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MaterialButtonCheckedChangeEvent> = corbindReceiveChannel(scope, capacity) {
     checkSelectionMode(this@buttonCheckedChangeEvents)
     val listener = listener(scope, ::trySend)
     addOnButtonCheckedListener(listener)
-    invokeOnClose { removeOnButtonCheckedListener(listener) }
+    awaitClose { removeOnButtonCheckedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialButtonToggleGroupCheckedChanges.kt
@@ -103,12 +103,12 @@ suspend fun MaterialButtonToggleGroup.buttonCheckedChanges(
 fun MaterialButtonToggleGroup.buttonCheckedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     checkSelectionMode(this@buttonCheckedChanges)
     trySend(checkedButtonId)
     val listener = listener(this@buttonCheckedChanges, scope, ::trySend)
     addOnButtonCheckedListener(listener)
-    invokeOnClose { removeOnButtonCheckedListener(listener) }
+    awaitClose { removeOnButtonCheckedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialCardViewCheckedChanges.kt
@@ -94,12 +94,12 @@ suspend fun MaterialCardView.checkedChanges(
 fun MaterialCardView.checkedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     checkCheckableState(this@checkedChanges)
     trySend(isChecked)
     val listener = listener(scope, ::trySend)
     setOnCheckedChangeListener(listener)
-    invokeOnClose { setOnCheckedChangeListener(null) }
+    awaitClose { setOnCheckedChangeListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerCancels.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerCancels.kt
@@ -96,10 +96,10 @@ suspend fun <S> MaterialDatePicker<S>.cancels(
 fun <S> MaterialDatePicker<S>.cancels(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnCancelListener(listener)
-    invokeOnClose { removeOnCancelListener(listener) }
+    awaitClose { removeOnCancelListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerDismisses.kt
@@ -86,10 +86,10 @@ suspend fun <S> MaterialDatePicker<S>.dismisses(
 fun <S> MaterialDatePicker<S>.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnDismissListener(listener)
-    invokeOnClose { removeOnDismissListener(listener) }
+    awaitClose { removeOnDismissListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerNegativeClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerNegativeClicks.kt
@@ -84,10 +84,10 @@ suspend fun <S> MaterialDatePicker<S>.negativeClicks(
 fun <S> MaterialDatePicker<S>.negativeClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnNegativeButtonClickListener(listener)
-    invokeOnClose { removeOnNegativeButtonClickListener(listener) }
+    awaitClose { removeOnNegativeButtonClickListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerPositiveClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialDatePickerPositiveClicks.kt
@@ -84,10 +84,10 @@ suspend fun <S> MaterialDatePicker<S>.positiveClicks(
 fun <S> MaterialDatePicker<S>.positiveClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<S> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<S> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnPositiveButtonClickListener(listener)
-    invokeOnClose { removeOnPositiveButtonClickListener(listener) }
+    awaitClose { removeOnPositiveButtonClickListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerCancels.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerCancels.kt
@@ -96,10 +96,10 @@ suspend fun MaterialTimePicker.cancels(
 fun MaterialTimePicker.cancels(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnCancelListener(listener)
-    invokeOnClose { removeOnCancelListener(listener) }
+    awaitClose { removeOnCancelListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerDismisses.kt
@@ -86,10 +86,10 @@ suspend fun MaterialTimePicker.dismisses(
 fun MaterialTimePicker.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnDismissListener(listener)
-    invokeOnClose { removeOnDismissListener(listener) }
+    awaitClose { removeOnDismissListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerNegativeClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerNegativeClicks.kt
@@ -84,10 +84,10 @@ suspend fun MaterialTimePicker.negativeClicks(
 fun MaterialTimePicker.negativeClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnNegativeButtonClickListener(listener)
-    invokeOnClose { removeOnNegativeButtonClickListener(listener) }
+    awaitClose { removeOnNegativeButtonClickListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerPositiveClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/MaterialTimePickerPositiveClicks.kt
@@ -84,10 +84,10 @@ suspend fun MaterialTimePicker.positiveClicks(
 fun MaterialTimePicker.positiveClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnPositiveButtonClickListener(listener)
-    invokeOnClose { removeOnPositiveButtonClickListener(listener) }
+    awaitClose { removeOnPositiveButtonClickListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemReselections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemReselections.kt
@@ -92,9 +92,9 @@ suspend fun NavigationBarView.itemReselections(
 fun NavigationBarView.itemReselections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnItemReselectedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnItemReselectedListener(null) }
+    awaitClose { setOnItemReselectedListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationBarViewItemSelections.kt
@@ -95,10 +95,10 @@ suspend fun NavigationBarView.itemSelections(
 fun NavigationBarView.itemSelections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setInitialValue(this@itemSelections, ::trySend)
     setOnItemSelectedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnItemSelectedListener(null) }
+    awaitClose { setOnItemSelectedListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationViewItemSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/NavigationViewItemSelections.kt
@@ -95,10 +95,10 @@ suspend fun NavigationView.itemSelections(
 fun NavigationView.itemSelections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setInitialValue(this@itemSelections, ::trySend)
     setNavigationItemSelectedListener(listener(scope, ::trySend))
-    invokeOnClose { setNavigationItemSelectedListener(null) }
+    awaitClose { setNavigationItemSelectedListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderTouches.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderTouches.kt
@@ -83,10 +83,10 @@ suspend fun RangeSlider.touches(
 fun RangeSlider.touches(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnSliderTouchListener(listener)
-    invokeOnClose { removeOnSliderTouchListener(listener) }
+    awaitClose { removeOnSliderTouchListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChangeEvents.kt
@@ -98,11 +98,11 @@ suspend fun RangeSlider.valuesChangeEvents(
 fun RangeSlider.valuesChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RangeSliderChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RangeSliderChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val event = initialValue(this@valuesChangeEvents).also { trySend(it) }
     val listener = listener(scope, ::trySend).apply { previousValues = event.previousValues }
     addOnChangeListener(listener)
-    invokeOnClose { removeOnChangeListener(listener) }
+    awaitClose { removeOnChangeListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/RangeSliderValuesChanges.kt
@@ -87,11 +87,11 @@ suspend fun RangeSlider.valuesChanges(
 fun RangeSlider.valuesChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<List<Float>> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<List<Float>> = corbindReceiveChannel(scope, capacity) {
     trySend(values)
     val listener = listener(scope, ::trySend)
     addOnChangeListener(listener)
-    invokeOnClose { removeOnChangeListener(listener) }
+    awaitClose { removeOnChangeListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchBarNavigationClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchBarNavigationClicks.kt
@@ -97,9 +97,9 @@ suspend fun SearchBar.navigationClicks(
 fun SearchBar.navigationClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setNavigationOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setNavigationOnClickListener(null) }
+    awaitClose { setNavigationOnClickListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChangeEvents.kt
@@ -93,10 +93,10 @@ suspend fun SearchView.transitionStateChangeEvents(
 fun SearchView.transitionStateChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SearchViewTransitionStateChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SearchViewTransitionStateChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addTransitionListener(listener)
-    invokeOnClose { removeTransitionListener(listener) }
+    awaitClose { removeTransitionListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SearchViewTransitionStateChanges.kt
@@ -84,10 +84,10 @@ suspend fun SearchView.transitionStateChanges(
 fun SearchView.transitionStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SearchView.TransitionState> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SearchView.TransitionState> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addTransitionListener(listener)
-    invokeOnClose { removeTransitionListener(listener) }
+    awaitClose { removeTransitionListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorSlides.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorSlides.kt
@@ -87,11 +87,11 @@ suspend fun View.sideSheetSlides(
 fun View.sideSheetSlides(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     val behavior = getSideSheetBehavior()
     val callback = callback(scope, ::trySend)
     behavior.addCallback(callback)
-    invokeOnClose { behavior.removeCallback(callback) }
+    awaitClose { behavior.removeCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SideSheetBehaviorStateChanges.kt
@@ -92,12 +92,12 @@ suspend fun View.sideSheetStateChanges(
 fun View.sideSheetStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val behavior = getSideSheetBehavior()
     trySend(behavior.state)
     val callback = callback(scope, ::trySend)
     behavior.addCallback(callback)
-    invokeOnClose { behavior.removeCallback(callback) }
+    awaitClose { behavior.removeCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderTouches.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderTouches.kt
@@ -83,10 +83,10 @@ suspend fun Slider.touches(
 fun Slider.touches(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnSliderTouchListener(listener)
-    invokeOnClose { removeOnSliderTouchListener(listener) }
+    awaitClose { removeOnSliderTouchListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChangeEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChangeEvents.kt
@@ -95,11 +95,11 @@ suspend fun Slider.valueChangeEvents(
 fun Slider.valueChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SliderChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SliderChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val event = initialValue(this@valueChangeEvents).also(::trySend)
     val listener = listener(scope, ::trySend).apply { previousValue = event.previousValue }
     addOnChangeListener(listener)
-    invokeOnClose { removeOnChangeListener(listener) }
+    awaitClose { removeOnChangeListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SliderValueChanges.kt
@@ -87,11 +87,11 @@ suspend fun Slider.valueChanges(
 fun Slider.valueChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     trySend(value)
     val listener = listener(scope, ::trySend)
     addOnChangeListener(listener)
-    invokeOnClose { removeOnChangeListener(listener) }
+    awaitClose { removeOnChangeListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarDismisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarDismisses.kt
@@ -83,10 +83,10 @@ suspend fun Snackbar.dismisses(
 fun Snackbar.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     addCallback(callback)
-    invokeOnClose { removeCallback(callback) }
+    awaitClose { removeCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarShown.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SnackbarShown.kt
@@ -83,10 +83,10 @@ suspend fun Snackbar.shown(
 fun Snackbar.shown(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Snackbar> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Snackbar> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     addCallback(callback)
-    invokeOnClose { removeCallback(callback) }
+    awaitClose { removeCallback(callback) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDesmisses.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDesmisses.kt
@@ -93,10 +93,10 @@ suspend fun View.dismisses(
 fun View.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<View> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<View> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBehavior(this@dismisses)
     behavior.listener = listener(scope, ::trySend)
-    invokeOnClose { behavior.setListener(null) }
+    awaitClose { behavior.setListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDragStateChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/SwipeDismissBehaviorDragStateChanges.kt
@@ -92,10 +92,10 @@ suspend fun View.dragStateChanges(
 fun View.dragStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val behavior = getBehavior(this@dragStateChanges)
     behavior.listener = listener(scope, ::trySend)
-    invokeOnClose { behavior.setListener(null) }
+    awaitClose { behavior.setListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelectionEvents.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelectionEvents.kt
@@ -123,11 +123,11 @@ suspend fun TabLayout.selectionEvents(
 fun TabLayout.selectionEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TabLayoutSelectionEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TabLayoutSelectionEvent> = corbindReceiveChannel(scope, capacity) {
     setInitialValue(this@selectionEvents, ::trySend)
     val listener = listener(scope, this@selectionEvents, ::trySend)
     addOnTabSelectedListener(listener)
-    invokeOnClose { removeOnTabSelectedListener(listener) }
+    awaitClose { removeOnTabSelectedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelections.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TabLayoutSelections.kt
@@ -86,11 +86,11 @@ suspend fun TabLayout.selections(
 fun TabLayout.selections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TabLayout.Tab> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TabLayout.Tab> = corbindReceiveChannel(scope, capacity) {
     setInitialValue(this@selections, ::trySend)
     val listener = listener(scope, ::trySend)
     addOnTabSelectedListener(listener)
-    invokeOnClose { removeOnTabSelectedListener(listener) }
+    awaitClose { removeOnTabSelectedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconChanges.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconChanges.kt
@@ -86,10 +86,10 @@ suspend fun TextInputLayout.endIconChanges(
 fun TextInputLayout.endIconChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnEndIconChangedListener(listener)
-    invokeOnClose { removeOnEndIconChangedListener(listener) }
+    awaitClose { removeOnEndIconChangedListener(listener) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconClicks.kt
@@ -92,9 +92,9 @@ suspend fun TextInputLayout.endIconClicks(
 fun TextInputLayout.endIconClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setEndIconOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setEndIconOnClickListener(null) }
+    awaitClose { setEndIconOnClickListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconLongClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutEndIconLongClicks.kt
@@ -102,9 +102,9 @@ fun TextInputLayout.endIconLongClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: () -> Boolean = AlwaysTrue,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setEndIconOnLongClickListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setEndIconOnLongClickListener(null) }
+    awaitClose { setEndIconOnLongClickListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconClicks.kt
@@ -92,9 +92,9 @@ suspend fun TextInputLayout.startIconClicks(
 fun TextInputLayout.startIconClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setStartIconOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setStartIconOnClickListener(null) }
+    awaitClose { setStartIconOnClickListener(null) }
 }
 
 /**

--- a/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconLongClicks.kt
+++ b/corbind-material/src/main/kotlin/ru/ldralighieri/corbind/material/TextInputLayoutStartIconLongClicks.kt
@@ -102,9 +102,9 @@ fun TextInputLayout.startIconLongClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: () -> Boolean = AlwaysTrue,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setStartIconOnLongClickListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setStartIconOnLongClickListener(null) }
+    awaitClose { setStartIconOnLongClickListener(null) }
 }
 
 /**

--- a/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChangeEvents.kt
+++ b/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChangeEvents.kt
@@ -95,10 +95,10 @@ suspend fun NavController.destinationChangeEvents(
 fun NavController.destinationChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<NavControllerOnDestinationChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<NavControllerOnDestinationChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnDestinationChangedListener(listener)
-    invokeOnClose { removeOnDestinationChangedListener(listener) }
+    awaitClose { removeOnDestinationChangedListener(listener) }
 }
 
 /**

--- a/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChanges.kt
+++ b/corbind-navigation/src/main/kotlin/ru/ldralighieri/corbind/navigation/NavControllerOnDestinationChanges.kt
@@ -84,10 +84,10 @@ suspend fun NavController.destinationChanges(
 fun NavController.destinationChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<NavDestination> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<NavDestination> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnDestinationChangedListener(listener)
-    invokeOnClose { removeOnDestinationChangedListener(listener) }
+    awaitClose { removeOnDestinationChangedListener(listener) }
 }
 
 /**

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerAdapterDataChanges.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerAdapterDataChanges.kt
@@ -87,11 +87,11 @@ suspend fun <T : RecyclerView.Adapter<out RecyclerView.ViewHolder>> T.dataChange
 fun <T : RecyclerView.Adapter<out RecyclerView.ViewHolder>> T.dataChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<T> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<T> = corbindReceiveChannel(scope, capacity) {
     trySend(this@dataChanges)
     val dataObserver = observer(scope, this@dataChanges, ::trySend)
     registerAdapterDataObserver(dataObserver)
-    invokeOnClose { unregisterAdapterDataObserver(dataObserver) }
+    awaitClose { unregisterAdapterDataObserver(dataObserver) }
 }
 
 /**

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewChildAttachStateChangeEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewChildAttachStateChangeEvents.kt
@@ -118,10 +118,10 @@ suspend fun RecyclerView.childAttachStateChangeEvents(
 fun RecyclerView.childAttachStateChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RecyclerViewChildAttachStateChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RecyclerViewChildAttachStateChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, this@childAttachStateChangeEvents, ::trySend)
     addOnChildAttachStateChangeListener(listener)
-    invokeOnClose { removeOnChildAttachStateChangeListener(listener) }
+    awaitClose { removeOnChildAttachStateChangeListener(listener) }
 }
 
 /**

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewFlingEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewFlingEvents.kt
@@ -98,9 +98,9 @@ suspend fun RecyclerView.flingEvents(
 fun RecyclerView.flingEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RecyclerViewFlingEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RecyclerViewFlingEvent> = corbindReceiveChannel(scope, capacity) {
     onFlingListener = listener(scope, this@flingEvents, ::trySend)
-    invokeOnClose { onFlingListener = null }
+    awaitClose { onFlingListener = null }
 }
 
 /**

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollEvents.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollEvents.kt
@@ -90,10 +90,10 @@ suspend fun RecyclerView.scrollEvents(
 fun RecyclerView.scrollEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RecyclerViewScrollEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RecyclerViewScrollEvent> = corbindReceiveChannel(scope, capacity) {
     val scrollListener = listener(scope, ::trySend)
     addOnScrollListener(scrollListener)
-    invokeOnClose { removeOnScrollListener(scrollListener) }
+    awaitClose { removeOnScrollListener(scrollListener) }
 }
 
 /**

--- a/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollStateChanges.kt
+++ b/corbind-recyclerview/src/main/kotlin/ru/ldralighieri/corbind/recyclerview/RecyclerViewScrollStateChanges.kt
@@ -83,10 +83,10 @@ suspend fun RecyclerView.scrollStateChanges(
 fun RecyclerView.scrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val scrollListener = listener(scope, ::trySend)
     addOnScrollListener(scrollListener)
-    invokeOnClose { removeOnScrollListener(scrollListener) }
+    awaitClose { removeOnScrollListener(scrollListener) }
 }
 
 /**

--- a/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutPaneOpens.kt
+++ b/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutPaneOpens.kt
@@ -92,11 +92,11 @@ suspend fun SlidingPaneLayout.panelOpens(
 fun SlidingPaneLayout.panelOpens(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     trySend(isOpen)
     val listener = listener(scope, ::trySend)
     addPanelSlideListener(listener)
-    invokeOnClose { removePanelSlideListener(listener) }
+    awaitClose { removePanelSlideListener(listener) }
 }
 
 /**

--- a/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutSlides.kt
+++ b/corbind-slidingpanelayout/src/main/kotlin/ru/ldralighieri/corbind/slidingpanelayout/SlidingPaneLayoutSlides.kt
@@ -88,10 +88,10 @@ suspend fun SlidingPaneLayout.panelSlides(
 fun SlidingPaneLayout.panelSlides(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addPanelSlideListener(listener)
-    invokeOnClose { removePanelSlideListener(listener) }
+    awaitClose { removePanelSlideListener(listener) }
 }
 
 /**

--- a/corbind-swiperefreshlayout/src/main/kotlin/ru/ldralighieri/corbind/swiperefreshlayout/SwipeRefreshLayoutRefreshes.kt
+++ b/corbind-swiperefreshlayout/src/main/kotlin/ru/ldralighieri/corbind/swiperefreshlayout/SwipeRefreshLayoutRefreshes.kt
@@ -91,9 +91,9 @@ suspend fun SwipeRefreshLayout.refreshes(
 fun SwipeRefreshLayout.refreshes(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnRefreshListener(listener(scope, ::trySend))
-    invokeOnClose { setOnRefreshListener(null) }
+    awaitClose { setOnRefreshListener(null) }
 }
 
 /**

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollEvents.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollEvents.kt
@@ -91,10 +91,10 @@ suspend fun ViewPager.pageScrollEvents(
 fun ViewPager.pageScrollEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewPagerPageScrollEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewPagerPageScrollEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, this@pageScrollEvents, ::trySend)
     addOnPageChangeListener(listener)
-    invokeOnClose { removeOnPageChangeListener(listener) }
+    awaitClose { removeOnPageChangeListener(listener) }
 }
 
 /**

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollStateChanges.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageScrollStateChanges.kt
@@ -83,10 +83,10 @@ suspend fun ViewPager.pageScrollStateChanges(
 fun ViewPager.pageScrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnPageChangeListener(listener)
-    invokeOnClose { removeOnPageChangeListener(listener) }
+    awaitClose { removeOnPageChangeListener(listener) }
 }
 
 /**

--- a/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageSelections.kt
+++ b/corbind-viewpager/src/main/kotlin/ru/ldralighieri/corbind/viewpager/ViewPagerPageSelections.kt
@@ -88,11 +88,11 @@ suspend fun ViewPager.pageSelections(
 fun ViewPager.pageSelections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     trySend(currentItem)
     val listener = listener(scope, ::trySend)
     addOnPageChangeListener(listener)
-    invokeOnClose { removeOnPageChangeListener(listener) }
+    awaitClose { removeOnPageChangeListener(listener) }
 }
 
 /**

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollEvents.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollEvents.kt
@@ -91,10 +91,10 @@ suspend fun ViewPager2.pageScrollEvents(
 fun ViewPager2.pageScrollEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewPager2PageScrollEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewPager2PageScrollEvent> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, this@pageScrollEvents, ::trySend)
     registerOnPageChangeCallback(callback)
-    invokeOnClose { unregisterOnPageChangeCallback(callback) }
+    awaitClose { unregisterOnPageChangeCallback(callback) }
 }
 
 /**

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollStateChanges.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageScrollStateChanges.kt
@@ -83,10 +83,10 @@ suspend fun ViewPager2.pageScrollStateChanges(
 fun ViewPager2.pageScrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     val callback = callback(scope, ::trySend)
     registerOnPageChangeCallback(callback)
-    invokeOnClose { unregisterOnPageChangeCallback(callback) }
+    awaitClose { unregisterOnPageChangeCallback(callback) }
 }
 
 /**

--- a/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageSelections.kt
+++ b/corbind-viewpager2/src/main/kotlin/ru/ldralighieri/corbind/viewpager2/ViewPager2PageSelections.kt
@@ -87,11 +87,11 @@ suspend fun ViewPager2.pageSelections(
 fun ViewPager2.pageSelections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     trySend(currentItem)
     val callback = callback(scope, ::trySend)
     registerOnPageChangeCallback(callback)
-    invokeOnClose { unregisterOnPageChangeCallback(callback) }
+    awaitClose { unregisterOnPageChangeCallback(callback) }
 }
 
 /**

--- a/corbind/build.gradle.kts
+++ b/corbind/build.gradle.kts
@@ -28,4 +28,7 @@ android {
 dependencies {
     api(libs.kotlin.coroutines.android)
     api(libs.androidx.annotation)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/app/DatePickerDialogDateSetEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/app/DatePickerDialogDateSetEvents.kt
@@ -106,9 +106,9 @@ suspend fun DatePickerDialog.dateSetEvents(
 fun DatePickerDialog.dateSetEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<DatePickerDialogSetEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<DatePickerDialogSetEvent> = corbindReceiveChannel(scope, capacity) {
     setOnDateSetListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDateSetListener(null) }
+    awaitClose { setOnDateSetListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/content/ContextReceivesBroadcast.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/content/ContextReceivesBroadcast.kt
@@ -106,7 +106,7 @@ fun Context.receivesBroadcast(
     scope: CoroutineScope,
     intentFilter: IntentFilter,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Intent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Intent> = corbindReceiveChannel(scope, capacity) {
     val receiver = receiver(scope, ::trySend)
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
@@ -115,7 +115,7 @@ fun Context.receivesBroadcast(
         registerReceiver(receiver, intentFilter, Context.RECEIVER_NOT_EXPORTED)
     }
 
-    invokeOnClose { unregisterReceiver(receiver) }
+    awaitClose { unregisterReceiver(receiver) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/internal/CorbindReceiveChannel.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/internal/CorbindReceiveChannel.kt
@@ -17,11 +17,104 @@
 package ru.ldralighieri.corbind.internal
 
 import androidx.annotation.RestrictTo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlin.coroutines.CoroutineContext
 
+/**
+ * Creates a hot channel owned by [scope]. Registration and cleanup in [block] run on the Android
+ * main thread. The block must suspend with `awaitClose`. Completion of the Job in [scope], including
+ * its cancelling phase, cancels the channel and removes the binding. Cancelling the returned channel
+ * removes the binding without cancelling [scope].
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-inline fun <T> corbindReceiveChannel(
+@OptIn(ExperimentalCoroutinesApi::class)
+fun <T> corbindReceiveChannel(
+    scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-    block: Channel<T>.() -> Unit,
-): ReceiveChannel<T> = Channel<T>(capacity).apply(block)
+    block: suspend ProducerScope<T>.() -> Unit,
+): ReceiveChannel<T> {
+    val parentJob: Job? = scope.coroutineContext[Job]
+
+    if (parentJob?.isActive == false) {
+        return Channel<T>(capacity).apply { cancel(null.scopeCancellationException()) }
+    }
+
+    // A detached producer lets a normally completing parent Job finish instead of waiting forever
+    // for this binding's awaitClose. The completion handlers below retain one-way ownership.
+    val producerScope = object : CoroutineScope {
+        override val coroutineContext: CoroutineContext = scope.coroutineContext.minusKey(Job)
+    }
+
+    val channel: ReceiveChannel<T> =
+        producerScope.produce(context = Dispatchers.Main.immediate, capacity) {
+            if (parentJob?.isActive == false) throw null.scopeCancellationException()
+            block()
+        }
+
+    parentJob?.cancelChannelOnCompletion(channel, channel as Job)
+
+    return channel
+}
+
+@OptIn(InternalCoroutinesApi::class)
+private fun Job.cancelChannelOnCompletion(
+    channel: ReceiveChannel<*>,
+    channelJob: Job,
+) {
+    val parentHandle = CompletionHandle()
+    channelJob.invokeOnCompletion { parentHandle.dispose() }
+
+    // Observe the cancelling phase so a non-cooperative sibling cannot keep an Android callback
+    // registered indefinitely. This handler also runs once on normal Job completion.
+    parentHandle.attach(
+        invokeOnCompletion(onCancelling = true, invokeImmediately = true) { cause ->
+            channel.cancel(cause.scopeCancellationException())
+        },
+    )
+}
+
+private class CompletionHandle {
+
+    private var handle: DisposableHandle? = null
+    private var disposed = false
+
+    fun attach(handle: DisposableHandle) {
+        val disposeNow: Boolean = synchronized(this) {
+            if (disposed) {
+                true
+            } else {
+                this.handle = handle
+                false
+            }
+        }
+
+        if (disposeNow) handle.dispose()
+    }
+
+    fun dispose() {
+        val handleToDispose: DisposableHandle? = synchronized(this) {
+            if (disposed) return
+            disposed = true
+            handle.also { handle = null }
+        }
+
+        handleToDispose?.dispose()
+    }
+}
+
+private fun Throwable?.scopeCancellationException(): CancellationException =
+    when (val cause = this) {
+        is CancellationException -> cause
+        null -> CancellationException("The owning CoroutineScope has completed")
+        else -> CancellationException("The owning CoroutineScope has completed").apply(::initCause)
+    }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemActionViewEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemActionViewEvents.kt
@@ -127,9 +127,9 @@ fun MenuItem.actionViewEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (MenuItemActionViewEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<MenuItemActionViewEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItemActionViewEvent> = corbindReceiveChannel(scope, capacity) {
     setOnActionExpandListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnActionExpandListener(null) }
+    awaitClose { setOnActionExpandListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/MenuItemClicks.kt
@@ -101,9 +101,9 @@ fun MenuItem.clicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (MenuItem) -> Boolean = AlwaysTrue,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttachEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttachEvents.kt
@@ -109,10 +109,10 @@ suspend fun View.attachEvents(
 fun View.attachEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewAttachEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewAttachEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnAttachStateChangeListener(listener)
-    invokeOnClose { removeOnAttachStateChangeListener(listener) }
+    awaitClose { removeOnAttachStateChangeListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttaches.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewAttaches.kt
@@ -83,10 +83,10 @@ suspend fun View.attaches(
 fun View.attaches(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, true, ::trySend)
     addOnAttachStateChangeListener(listener)
-    invokeOnClose { removeOnAttachStateChangeListener(listener) }
+    awaitClose { removeOnAttachStateChangeListener(listener) }
 }
 
 /**
@@ -161,10 +161,10 @@ suspend fun View.detaches(
 fun View.detaches(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, false, ::trySend)
     addOnAttachStateChangeListener(listener)
-    invokeOnClose { removeOnAttachStateChangeListener(listener) }
+    awaitClose { removeOnAttachStateChangeListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewClicks.kt
@@ -91,9 +91,9 @@ suspend fun View.clicks(
 fun View.clicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnClickListener(null) }
+    awaitClose { setOnClickListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewDrags.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewDrags.kt
@@ -100,9 +100,9 @@ fun View.drags(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (DragEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<DragEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<DragEvent> = corbindReceiveChannel(scope, capacity) {
     setOnDragListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnDragListener(null) }
+    awaitClose { setOnDragListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewFocusChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewFocusChanges.kt
@@ -95,10 +95,10 @@ suspend fun View.focusChanges(
 fun View.focusChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     trySend(hasFocus())
     onFocusChangeListener = listener(scope, ::trySend)
-    invokeOnClose { onFocusChangeListener = null }
+    awaitClose { onFocusChangeListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewGroupHierarchyChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewGroupHierarchyChangeEvents.kt
@@ -121,9 +121,9 @@ suspend fun ViewGroup.changeEvents(
 fun ViewGroup.changeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewGroupHierarchyChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewGroupHierarchyChangeEvent> = corbindReceiveChannel(scope, capacity) {
     setOnHierarchyChangeListener(listener(scope, this@changeEvents, ::trySend))
-    invokeOnClose { setOnHierarchyChangeListener(null) }
+    awaitClose { setOnHierarchyChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewHovers.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewHovers.kt
@@ -102,9 +102,9 @@ fun View.hovers(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (MotionEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<MotionEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MotionEvent> = corbindReceiveChannel(scope, capacity) {
     setOnHoverListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnHoverListener(null) }
+    awaitClose { setOnHoverListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewKeys.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewKeys.kt
@@ -100,9 +100,9 @@ fun View.keys(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (KeyEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<KeyEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<KeyEvent> = corbindReceiveChannel(scope, capacity) {
     setOnKeyListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnKeyListener(null) }
+    awaitClose { setOnKeyListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChangeEvents.kt
@@ -96,10 +96,10 @@ suspend fun View.layoutChangeEvents(
 fun View.layoutChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewLayoutChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewLayoutChangeEvent> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnLayoutChangeListener(listener)
-    invokeOnClose { removeOnLayoutChangeListener(listener) }
+    awaitClose { removeOnLayoutChangeListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLayoutChanges.kt
@@ -83,10 +83,10 @@ suspend fun View.layoutChanges(
 fun View.layoutChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     addOnLayoutChangeListener(listener)
-    invokeOnClose { removeOnLayoutChangeListener(listener) }
+    awaitClose { removeOnLayoutChangeListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLongClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewLongClicks.kt
@@ -101,9 +101,9 @@ fun View.longClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: () -> Boolean = AlwaysTrue,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnLongClickListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnLongClickListener(null) }
+    awaitClose { setOnLongClickListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewScrollChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewScrollChangeEvents.kt
@@ -105,9 +105,9 @@ suspend fun View.scrollChangeEvents(
 fun View.scrollChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<ViewScrollChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<ViewScrollChangeEvent> = corbindReceiveChannel(scope, capacity) {
     setOnScrollChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnScrollChangeListener(null) }
+    awaitClose { setOnScrollChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewSystemUiVisibilityChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewSystemUiVisibilityChanges.kt
@@ -128,9 +128,9 @@ suspend fun View.systemUiVisibilityChanges(
 fun View.systemUiVisibilityChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     setOnSystemUiVisibilityChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnSystemUiVisibilityChangeListener(null) }
+    awaitClose { setOnSystemUiVisibilityChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTouches.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTouches.kt
@@ -103,9 +103,9 @@ fun View.touches(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (MotionEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<MotionEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MotionEvent> = corbindReceiveChannel(scope, capacity) {
     setOnTouchListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnTouchListener(null) }
+    awaitClose { setOnTouchListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverDraws.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverDraws.kt
@@ -89,10 +89,10 @@ suspend fun View.draws(
 fun View.draws(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     viewTreeObserver.addOnDrawListener(listener)
-    invokeOnClose { viewTreeObserver.removeOnDrawListener(listener) }
+    awaitClose { viewTreeObserver.removeOnDrawListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverGlobalLayouts.kt
@@ -87,11 +87,11 @@ suspend fun View.globalLayouts(
 fun View.globalLayouts(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, ::trySend)
     val observer = viewTreeObserver
     observer.addOnGlobalLayoutListener(listener)
-    invokeOnClose {
+    awaitClose {
         removeOnGlobalLayoutListener(observer, listener)
     }
 }

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverPreDraws.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewTreeObserverPreDraws.kt
@@ -90,10 +90,10 @@ fun View.preDraws(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     proceedDrawingPass: () -> Boolean,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     val listener = listener(scope, proceedDrawingPass, ::trySend)
     viewTreeObserver.addOnPreDrawListener(listener)
-    invokeOnClose { viewTreeObserver.removeOnPreDrawListener(listener) }
+    awaitClose { viewTreeObserver.removeOnPreDrawListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewWindowInsetsApplyEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/view/ViewWindowInsetsApplyEvents.kt
@@ -94,9 +94,9 @@ suspend fun View.windowInsetsApplyEvents(
 fun View.windowInsetsApplyEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<WindowInsetsEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<WindowInsetsEvent> = corbindReceiveChannel(scope, capacity) {
     setOnApplyWindowInsetsListener(listener(scope, ::trySend))
-    invokeOnClose { setOnApplyWindowInsetsListener(null) }
+    awaitClose { setOnApplyWindowInsetsListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AbsListViewScrollEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AbsListViewScrollEvents.kt
@@ -100,9 +100,9 @@ suspend fun AbsListView.scrollEvents(
 fun AbsListView.scrollEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<AbsListViewScrollEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<AbsListViewScrollEvent> = corbindReceiveChannel(scope, capacity) {
     setOnScrollListener(listener(scope, ::trySend))
-    invokeOnClose { setOnScrollListener(null) }
+    awaitClose { setOnScrollListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterDataChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterDataChanges.kt
@@ -88,11 +88,11 @@ suspend fun <T : Adapter> T.dataChanges(
 fun <T : Adapter> T.dataChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<T> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<T> = corbindReceiveChannel(scope, capacity) {
     trySend(this@dataChanges)
     val dataSetObserver = observer(scope, this@dataChanges, ::trySend)
     registerDataSetObserver(dataSetObserver)
-    invokeOnClose { unregisterDataSetObserver(dataSetObserver) }
+    awaitClose { unregisterDataSetObserver(dataSetObserver) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClickEvents.kt
@@ -101,9 +101,9 @@ suspend fun <T : Adapter> AdapterView<T>.itemClickEvents(
 fun <T : Adapter> AdapterView<T>.itemClickEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<AdapterViewItemClickEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<AdapterViewItemClickEvent> = corbindReceiveChannel(scope, capacity) {
     onItemClickListener = listener(scope, ::trySend)
-    invokeOnClose { onItemClickListener = null }
+    awaitClose { onItemClickListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemClicks.kt
@@ -93,9 +93,9 @@ suspend fun <T : Adapter> AdapterView<T>.itemClicks(
 fun <T : Adapter> AdapterView<T>.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     onItemClickListener = listener(scope, ::trySend)
-    invokeOnClose { onItemClickListener = null }
+    awaitClose { onItemClickListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClickEvents.kt
@@ -112,9 +112,9 @@ fun <T : Adapter> AdapterView<T>.itemLongClickEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (AdapterViewItemLongClickEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<AdapterViewItemLongClickEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<AdapterViewItemLongClickEvent> = corbindReceiveChannel(scope, capacity) {
     onItemLongClickListener = listener(scope, handled, ::trySend)
-    invokeOnClose { onItemLongClickListener = null }
+    awaitClose { onItemLongClickListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemLongClicks.kt
@@ -103,9 +103,9 @@ fun <T : Adapter> AdapterView<T>.itemLongClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: () -> Boolean = AlwaysTrue,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     onItemLongClickListener = listener(scope, handled, ::trySend)
-    invokeOnClose { onItemLongClickListener = null }
+    awaitClose { onItemLongClickListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemSelections.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewItemSelections.kt
@@ -98,10 +98,10 @@ suspend fun <T : Adapter> AdapterView<T>.itemSelections(
 fun <T : Adapter> AdapterView<T>.itemSelections(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     trySend(selectedItemPosition)
     onItemSelectedListener = listener(scope, ::trySend)
-    invokeOnClose { onItemSelectedListener = null }
+    awaitClose { onItemSelectedListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewSelectionEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AdapterViewSelectionEvents.kt
@@ -126,10 +126,10 @@ suspend fun <T : Adapter> AdapterView<T>.selectionEvents(
 fun <T : Adapter> AdapterView<T>.selectionEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<AdapterViewSelectionEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<AdapterViewSelectionEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@selectionEvents))
     onItemSelectedListener = listener(scope, ::trySend)
-    invokeOnClose { onItemSelectedListener = null }
+    awaitClose { onItemSelectedListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewDismisses.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewDismisses.kt
@@ -96,9 +96,9 @@ suspend fun AutoCompleteTextView.dismisses(
 fun AutoCompleteTextView.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnDismissListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDismissListener(null) }
+    awaitClose { setOnDismissListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewItemClickEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/AutoCompleteTextViewItemClickEvents.kt
@@ -94,9 +94,9 @@ suspend fun AutoCompleteTextView.itemClickEvents(
 fun AutoCompleteTextView.itemClickEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<AdapterViewItemClickEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<AdapterViewItemClickEvent> = corbindReceiveChannel(scope, capacity) {
     onItemClickListener = listener(scope, ::trySend)
-    invokeOnClose { onItemClickListener = null }
+    awaitClose { onItemClickListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CalendarViewDateChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CalendarViewDateChangeEvents.kt
@@ -105,10 +105,10 @@ suspend fun CalendarView.dateChangeEvents(
 fun CalendarView.dateChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<CalendarViewDateChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<CalendarViewDateChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@dateChangeEvents))
     setOnDateChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDateChangeListener(null) }
+    awaitClose { setOnDateChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CompoundButtonCheckedChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/CompoundButtonCheckedChanges.kt
@@ -95,10 +95,10 @@ suspend fun CompoundButton.checkedChanges(
 fun CompoundButton.checkedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Boolean> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Boolean> = corbindReceiveChannel(scope, capacity) {
     trySend(isChecked)
     setOnCheckedChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnCheckedChangeListener(null) }
+    awaitClose { setOnCheckedChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/DatePickerChangedEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/DatePickerChangedEvents.kt
@@ -108,10 +108,10 @@ suspend fun DatePicker.dateChangeEvents(
 fun DatePicker.dateChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<DateChangedEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<DateChangedEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(DateChangedEvent(this@dateChangeEvents, year, month, dayOfMonth))
     setOnDateChangedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDateChangedListener(null) }
+    awaitClose { setOnDateChangedListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerScrollStateChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerScrollStateChanges.kt
@@ -91,9 +91,9 @@ suspend fun NumberPicker.scrollStateChanges(
 fun NumberPicker.scrollStateChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     setOnScrollListener(listener(scope, ::trySend))
-    invokeOnClose { setOnScrollListener(null) }
+    awaitClose { setOnScrollListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerValueChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/NumberPickerValueChangeEvents.kt
@@ -103,10 +103,10 @@ suspend fun NumberPicker.valueChangeEvents(
 fun NumberPicker.valueChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<NumberPickerValueChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<NumberPickerValueChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(NumberPickerValueChangeEvent(this@valueChangeEvents, value, value))
     setOnValueChangedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnValueChangedListener(null) }
+    awaitClose { setOnValueChangedListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuDismisses.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuDismisses.kt
@@ -91,9 +91,9 @@ suspend fun PopupMenu.dismisses(
 fun PopupMenu.dismisses(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setOnDismissListener(listener(scope, ::trySend))
-    invokeOnClose { setOnDismissListener(null) }
+    awaitClose { setOnDismissListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/PopupMenuItemClicks.kt
@@ -92,9 +92,9 @@ suspend fun PopupMenu.itemClicks(
 fun PopupMenu.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RadioGroupCheckedChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RadioGroupCheckedChanges.kt
@@ -97,10 +97,10 @@ suspend fun RadioGroup.checkedChanges(
 fun RadioGroup.checkedChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     trySend(checkedRadioButtonId)
     setOnCheckedChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnCheckedChangeListener(null) }
+    awaitClose { setOnCheckedChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChangeEvents.kt
@@ -102,10 +102,10 @@ suspend fun RatingBar.ratingChangeEvents(
 fun RatingBar.ratingChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<RatingBarChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<RatingBarChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@ratingChangeEvents))
     onRatingBarChangeListener = listener(scope, ::trySend)
-    invokeOnClose { onRatingBarChangeListener = null }
+    awaitClose { onRatingBarChangeListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/RatingBarRatingChanges.kt
@@ -95,10 +95,10 @@ suspend fun RatingBar.ratingChanges(
 fun RatingBar.ratingChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Float> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Float> = corbindReceiveChannel(scope, capacity) {
     trySend(rating)
     onRatingBarChangeListener = listener(scope, ::trySend)
-    invokeOnClose { onRatingBarChangeListener = null }
+    awaitClose { onRatingBarChangeListener = null }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChangeEvents.kt
@@ -102,10 +102,10 @@ suspend fun SearchView.queryTextChangeEvents(
 fun SearchView.queryTextChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SearchViewQueryTextEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SearchViewQueryTextEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@queryTextChangeEvents))
     setOnQueryTextListener(listener(scope, this@queryTextChangeEvents, ::trySend))
-    invokeOnClose { setOnQueryTextListener(null) }
+    awaitClose { setOnQueryTextListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SearchViewQueryTextChanges.kt
@@ -96,10 +96,10 @@ suspend fun SearchView.queryTextChanges(
 fun SearchView.queryTextChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<CharSequence> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<CharSequence> = corbindReceiveChannel(scope, capacity) {
     trySend(query)
     setOnQueryTextListener(listener(scope, ::trySend))
-    invokeOnClose { setOnQueryTextListener(null) }
+    awaitClose { setOnQueryTextListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChangeEvents.kt
@@ -128,10 +128,10 @@ suspend fun SeekBar.changeEvents(
 fun SeekBar.changeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<SeekBarChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<SeekBarChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@changeEvents))
     setOnSeekBarChangeListener(listener(scope, ::trySend))
-    invokeOnClose { setOnSeekBarChangeListener(null) }
+    awaitClose { setOnSeekBarChangeListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/SeekBarChanges.kt
@@ -59,10 +59,10 @@ private fun SeekBar.changes(
     scope: CoroutineScope,
     capacity: Int,
     shouldBeFromUser: Boolean?,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     trySend(progress)
     setOnSeekBarChangeListener(listener(scope, shouldBeFromUser, ::trySend))
-    invokeOnClose { setOnSeekBarChangeListener(null) }
+    awaitClose { setOnSeekBarChangeListener(null) }
 }
 
 @CheckResult

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewAfterTextChangeEvents.kt
@@ -95,11 +95,11 @@ suspend fun TextView.afterTextChangeEvents(
 fun TextView.afterTextChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TextViewAfterTextChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TextViewAfterTextChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@afterTextChangeEvents))
     val listener = listener(scope, this@afterTextChangeEvents, ::trySend)
     addTextChangedListener(listener)
-    invokeOnClose { removeTextChangedListener(listener) }
+    awaitClose { removeTextChangedListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewBeforeTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewBeforeTextChangeEvents.kt
@@ -96,11 +96,11 @@ suspend fun TextView.beforeTextChangeEvents(
 fun TextView.beforeTextChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TextViewBeforeTextChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TextViewBeforeTextChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@beforeTextChangeEvents))
     val listener = listener(scope, this@beforeTextChangeEvents, ::trySend)
     addTextChangedListener(listener)
-    invokeOnClose { removeTextChangedListener(listener) }
+    awaitClose { removeTextChangedListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActionEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActionEvents.kt
@@ -109,9 +109,9 @@ fun TextView.editorActionEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (TextViewEditorActionEvent) -> Boolean = AlwaysTrue,
-): ReceiveChannel<TextViewEditorActionEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TextViewEditorActionEvent> = corbindReceiveChannel(scope, capacity) {
     setOnEditorActionListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnEditorActionListener(null) }
+    awaitClose { setOnEditorActionListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActions.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewEditorActions.kt
@@ -101,9 +101,9 @@ fun TextView.editorActions(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
     handled: (Int) -> Boolean = AlwaysTrue,
-): ReceiveChannel<Int> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Int> = corbindReceiveChannel(scope, capacity) {
     setOnEditorActionListener(listener(scope, handled, ::trySend))
-    invokeOnClose { setOnEditorActionListener(null) }
+    awaitClose { setOnEditorActionListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChangeEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChangeEvents.kt
@@ -98,11 +98,11 @@ suspend fun TextView.textChangeEvents(
 fun TextView.textChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TextViewTextChangeEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TextViewTextChangeEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(initialValue(this@textChangeEvents))
     val listener = listener(scope, this@textChangeEvents, ::trySend)
     addTextChangedListener(listener)
-    invokeOnClose { removeTextChangedListener(listener) }
+    awaitClose { removeTextChangedListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChanges.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TextViewTextChanges.kt
@@ -90,11 +90,11 @@ suspend fun TextView.textChanges(
 fun TextView.textChanges(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<CharSequence> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<CharSequence> = corbindReceiveChannel(scope, capacity) {
     trySend(text)
     val listener = listener(scope, ::trySend)
     addTextChangedListener(listener)
-    invokeOnClose { removeTextChangedListener(listener) }
+    awaitClose { removeTextChangedListener(listener) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TimePickerChangedEvents.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/TimePickerChangedEvents.kt
@@ -107,10 +107,10 @@ suspend fun TimePicker.timeChangeEvents(
 fun TimePicker.timeChangeEvents(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<TimeChangedEvent> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<TimeChangedEvent> = corbindReceiveChannel(scope, capacity) {
     trySend(TimeChangedEvent(this@timeChangeEvents, hour, minute))
     setOnTimeChangedListener(listener(scope, ::trySend))
-    invokeOnClose { setOnTimeChangedListener(null) }
+    awaitClose { setOnTimeChangedListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarItemClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarItemClicks.kt
@@ -97,9 +97,9 @@ suspend fun Toolbar.itemClicks(
 fun Toolbar.itemClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<MenuItem> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<MenuItem> = corbindReceiveChannel(scope, capacity) {
     setOnMenuItemClickListener(listener(scope, ::trySend))
-    invokeOnClose { setOnMenuItemClickListener(null) }
+    awaitClose { setOnMenuItemClickListener(null) }
 }
 
 /**

--- a/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarNavigationClicks.kt
+++ b/corbind/src/main/kotlin/ru/ldralighieri/corbind/widget/ToolbarNavigationClicks.kt
@@ -97,9 +97,9 @@ suspend fun Toolbar.navigationClicks(
 fun Toolbar.navigationClicks(
     scope: CoroutineScope,
     capacity: Int = Channel.RENDEZVOUS,
-): ReceiveChannel<Unit> = corbindReceiveChannel(capacity) {
+): ReceiveChannel<Unit> = corbindReceiveChannel(scope, capacity) {
     setNavigationOnClickListener(listener(scope, ::trySend))
-    invokeOnClose { setNavigationOnClickListener(null) }
+    awaitClose { setNavigationOnClickListener(null) }
 }
 
 /**

--- a/corbind/src/test/kotlin/ru/ldralighieri/corbind/internal/CorbindReceiveChannelTest.kt
+++ b/corbind/src/test/kotlin/ru/ldralighieri/corbind/internal/CorbindReceiveChannelTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2026 Vladimir Raupov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ru.ldralighieri.corbind.internal
+
+import android.os.Build
+import android.os.Looper
+import android.view.View
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import ru.ldralighieri.corbind.view.clicks
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+@LooperMode(LooperMode.Mode.PAUSED)
+class CorbindReceiveChannelTest {
+
+    private lateinit var scope: CoroutineScope
+    private var binding: ReceiveChannel<*>? = null
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    }
+
+    @After
+    fun tearDown() {
+        binding?.cancel()
+        scope.cancel()
+        idleMainLooper()
+    }
+
+    @Test
+    fun `active scope registers binding on main thread`() {
+        // given
+        val registrations = AtomicInteger()
+        val registrationLooper = AtomicReference<Looper>()
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                registrations.incrementAndGet()
+                registrationLooper.set(Looper.myLooper())
+                awaitClose()
+            }
+        }
+
+        // when
+        assertEquals(0, registrations.get())
+        idleMainLooper()
+
+        // then
+        assertEquals(1, registrations.get())
+        assertSame(Looper.getMainLooper(), registrationLooper.get())
+        assertFalse(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    @Test
+    fun `already cancelled scope does not register binding`() {
+        // given
+        val registrations = AtomicInteger()
+        val cleanups = AtomicInteger()
+        scope.cancel()
+
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                registrations.incrementAndGet()
+                awaitClose { cleanups.incrementAndGet() }
+            }
+        }
+
+        idleMainLooper()
+
+        // then
+        assertEquals(0, registrations.get())
+        assertEquals(0, cleanups.get())
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    @Test
+    fun `scope cancellation before main dispatch does not register binding`() {
+        // given
+        val registrations = AtomicInteger()
+        val cleanups = AtomicInteger()
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                registrations.incrementAndGet()
+                awaitClose { cleanups.incrementAndGet() }
+            }
+        }
+
+        // when
+        runOnBackground { scope.cancel() }
+        idleMainLooper()
+
+        // then
+        assertEquals(0, registrations.get())
+        assertEquals(0, cleanups.get())
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    @Test
+    fun `channel cancellation before main dispatch does not register binding`() {
+        // given
+        val registrations = AtomicInteger()
+        val cleanups = AtomicInteger()
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                registrations.incrementAndGet()
+                awaitClose { cleanups.incrementAndGet() }
+            }
+        }
+
+        // when
+        runOnBackground { binding.requireChannel().cancel() }
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+        idleMainLooper()
+
+        // then
+        assertEquals(0, registrations.get())
+        assertEquals(0, cleanups.get())
+    }
+
+    @Test
+    fun `scope cancellation cleans up once on main thread`() {
+        // given
+        val cleanups = AtomicInteger()
+        val cleanupLooper = AtomicReference<Looper>()
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                awaitClose {
+                    cleanups.incrementAndGet()
+                    cleanupLooper.set(Looper.myLooper())
+                }
+            }
+        }
+
+        idleMainLooper()
+
+        // when
+        runOnBackground { scope.cancel() }
+        idleMainLooper()
+
+        binding.requireChannel().cancel()
+        idleMainLooper()
+
+        // then
+        assertEquals(1, cleanups.get())
+        assertSame(Looper.getMainLooper(), cleanupLooper.get())
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    @Test
+    fun `scope cancellation closes channel while sibling is still cancelling`() {
+        // given
+        val parentJob = SupervisorJob()
+        val siblingStarted = CountDownLatch(1)
+        val siblingCancelling = CountDownLatch(1)
+        val releaseSibling = CountDownLatch(1)
+        val siblingFinished = CountDownLatch(1)
+        val cleanups = AtomicInteger()
+        scope = CoroutineScope(parentJob + Dispatchers.Unconfined)
+        scope.launch(Dispatchers.Default) {
+            siblingStarted.countDown()
+            try {
+                awaitCancellation()
+            } finally {
+                try {
+                    withContext(NonCancellable) {
+                        siblingCancelling.countDown()
+                        releaseSibling.await()
+                    }
+                } finally {
+                    siblingFinished.countDown()
+                }
+            }
+        }
+
+        assertTrue(siblingStarted.await(5, TimeUnit.SECONDS))
+
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                awaitClose { cleanups.incrementAndGet() }
+            }
+        }
+
+        idleMainLooper()
+
+        try {
+            // when
+            runOnBackground { scope.cancel() }
+            assertTrue(siblingCancelling.await(5, TimeUnit.SECONDS))
+            idleMainLooper()
+
+            // then
+            assertFalse(parentJob.isCompleted)
+            assertEquals(1, cleanups.get())
+            assertTrue(binding.requireChannel().tryReceive().isClosed)
+        } finally {
+            releaseSibling.countDown()
+            assertTrue(siblingFinished.await(5, TimeUnit.SECONDS))
+        }
+    }
+
+    @Test
+    fun `normal scope job completion closes channel and cleans up on main thread`() {
+        // given
+        val parentJob = SupervisorJob()
+        val cleanups = AtomicInteger()
+        val cleanupLooper = AtomicReference<Looper>()
+        scope = CoroutineScope(parentJob + Dispatchers.Unconfined)
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                awaitClose {
+                    cleanups.incrementAndGet()
+                    cleanupLooper.set(Looper.myLooper())
+                }
+            }
+        }
+
+        idleMainLooper()
+
+        // when
+        assertTrue(runOnBackground { parentJob.complete() })
+        idleMainLooper()
+
+        // then
+        assertTrue(parentJob.isCompleted)
+        assertEquals(1, cleanups.get())
+        assertSame(Looper.getMainLooper(), cleanupLooper.get())
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    @Test
+    fun `channel cancellation cleans up on main without cancelling scope`() {
+        // given
+        val cleanups = AtomicInteger()
+        val cleanupLooper = AtomicReference<Looper>()
+        binding = runOnBackground {
+            corbindReceiveChannel<Unit>(scope, Channel.UNLIMITED) {
+                awaitClose {
+                    cleanups.incrementAndGet()
+                    cleanupLooper.set(Looper.myLooper())
+                }
+            }
+        }
+
+        idleMainLooper()
+
+        // when
+        runOnBackground { binding.requireChannel().cancel() }
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+        assertEquals(0, cleanups.get())
+        idleMainLooper()
+
+        // then
+        assertEquals(1, cleanups.get())
+        assertSame(Looper.getMainLooper(), cleanupLooper.get())
+        assertTrue(scope.coroutineContext[Job]?.isActive == true)
+    }
+
+    @Test
+    fun `view click listener is removed when scope is cancelled`() {
+        // given
+        val view = View(RuntimeEnvironment.getApplication())
+        binding = view.clicks(scope, Channel.UNLIMITED)
+        idleMainLooper()
+        assertTrue(view.hasOnClickListeners())
+        view.performClick()
+        assertEquals(Unit, binding.requireChannel().tryReceive().getOrThrow())
+
+        // when
+        runOnBackground { scope.cancel() }
+        idleMainLooper()
+
+        // then
+        assertFalse(view.hasOnClickListeners())
+        assertTrue(binding.requireChannel().tryReceive().isClosed)
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun ReceiveChannel<*>?.requireChannel(): ReceiveChannel<*> = requireNotNull(this)
+
+    private fun <T> runOnBackground(block: () -> T): T {
+        val result = AtomicReference<Result<T>>()
+        val thread = Thread { result.set(runCatching(block)) }
+        thread.start()
+        thread.join()
+        return result.get().getOrThrow()
+    }
+}


### PR DESCRIPTION
- Cancel receive channels and unregister Android callbacks when the owning CoroutineScope completes or starts cancellation.
- Migrate ReceiveChannel bindings to scope-aware creation and awaitClose cleanup.
- Add Robolectric coverage for lifecycle completion, cancellation races, and listener cleanup.
- Document the ReceiveChannel lifecycle ownership contract.